### PR TITLE
Turning off strict mode due to a bug

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,8 @@ site_name: Screwdriver Guide
 repo_url: https://github.com/screwdriver-cd/guide
 repo_name: GitHub
 site_description: All you need to know about Screwdriver and more
-strict: true
+# Due to bug in MKDocs: https://github.com/mkdocs/mkdocs/issues/974
+# strict: true
 theme: yeti
 copyright: Yahoo Inc. BSD-3-Clause
 


### PR DESCRIPTION
Apparently there's a bug in mkdocs that prevents using the moved themes with strict mode (filed here: https://github.com/mkdocs/mkdocs/issues/974)
