### PR TITLE
First stage of reorganization to improve the flow of information to the new user

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ extra_javascript: [js/vendor/jquery-3.1.0.min.js, js/yaml.js]
 pages:
     - Home: 'index.md'
     - Getting Started:
-        - Set up a Screwdriver Cluster: 'getting-started/cluster-setup.md'
+        - Set Up a Screwdriver Cluster: 'getting-started/cluster-setup.md'
         - Set Up a Datastore: 'getting-started/datastore-setup.md'
         - Create a Pipeline: 'getting-started/create-pipeline.md'
         - Config File Reference: 'getting-started/yaml.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,16 +12,17 @@ extra_javascript: [js/vendor/jquery-3.1.0.min.js, js/yaml.js]
 
 pages:
     - Home: 'index.md'
-    - Architecture:
-        - Overall: 'architecture/overall.md'
+    - Getting Started:
+        - Set up a Screwdriver Cluster: 'getting-started/cluster-setup.md'
+        - Set Up a Datastore: 'getting-started/datastore-setup.md'
+        - Create a Pipeline: 'getting-started/create-pipeline.md'
+        - Config File Reference: 'getting-started/yaml.md'
+    - Internals:
+        - Overall Architecture: 'architecture/overall.md'
         - API: 'architecture/api.md'
         - Execution Engines: 'architecture/execution-engines.md'
         - Domain Model: 'architecture/domain.md'
-    - Getting Started:
-        - Yaml Configuration: 'getting-started/yaml.md'
-        - Setting Up a Datastore: 'getting-started/datastore-setup.md'
-        - Setting Up a Cluster: 'getting-started/cluster-setup.md'
-        - Creating a Pipeline: 'getting-started/create-pipeline.md'
     - Community:
         - Contributing: 'community/contributing.md'
         - Support: 'community/support.md'
+ 


### PR DESCRIPTION
Start with Getting Started.  Guide them to get a pipeline created as soon as possible. 

Rename Architecture to Internals to better reflect entirety of docs in that section
