### PR TITLE
Changing CNAME to docs.screwdriver.cd and adding Google Analytics

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-screwdriver.cd
+docs.screwdriver.cd

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ theme_dir: themes/sd
 copyright: © 2016 Yahoo! Inc. All rights reserved.
 extra_css: [css/homepage.css, css/yaml.css]
 extra_javascript: [js/vendor/jquery-3.1.0.min.js, js/yaml.js]
+google_analytics: ['UA-88158708-1', 'docs.screwdriver.cd']
 
 pages:
     - Home: 'index.md'


### PR DESCRIPTION
This adjusts our generated CNAME and adds our new Google Analytics tracking courtesy of http://www.mkdocs.org/user-guide/configuration/#google_analytics

Issue: https://github.com/screwdriver-cd/screwdriver/issues/371