### PR TITLE
Fixing deployment by correctly scoping environment variable

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+source ./ci/git-ssh.sh
+mkdocs gh-deploy --clean

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,8 +15,7 @@ jobs:
       steps:
           - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
           - init: pip install -r requirements.txt
-          - ssh:  ./ci/git-ssh.sh
-          - deploy: mkdocs gh-deploy --clean
+          - deploy: ./deploy.sh
       secrets:
           # Pushing tags to Git
           - GIT_KEY


### PR DESCRIPTION
- Moves ssh setup and gh-deploy into a shell script
- Uses source `.` to export the SSH_AGENT variables for use in gh-deploy

Fixes https://github.com/screwdriver-cd/screwdriver/issues/345
Related to https://github.com/screwdriver-cd/screwdriver/issues/371