### PR TITLE
chore: omit virtualenv folder in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 site
+
+# For ignoring the python virtualenv
+venv


### PR DESCRIPTION
Cleaning up a bit of #59 

Adding the `virtualenv` folder into the `.gitignore` since we don't need to version control it.