### PR TITLE
Migrate to MkDocs v0.16

### DIFF
--- a/themes/sd/404.html
+++ b/themes/sd/404.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "main.html" %}
 
 {% block content %}
 

--- a/themes/sd/content.html
+++ b/themes/sd/content.html
@@ -1,9 +1,9 @@
-{% if meta.source %}
+{% if page.meta.source %}
 <div class="source-links">
-{% for filename in meta.source %}
+{% for filename in page.meta.source %}
     <span class="label label-primary">{{ filename }}</span>
 {% endfor %}
 </div>
 {% endif %}
 
-{{ content }}
+{{ page.content }}

--- a/themes/sd/main.html
+++ b/themes/sd/main.html
@@ -4,13 +4,13 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        {% if page_description %}<meta name="description" content="{{ page_description }}">{% endif %}
-        {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}
-        {% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}">{% endif %}
-        {% if favicon %}<link rel="shortcut icon" href="{{ base_url }}/{{ favicon }}">
+        {% if config.site_description %}<meta name="description" content="{{ config.site_description }}">{% endif %}
+        {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
+        {% if page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
+        {% if config.favicon %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">
         {% else %}<link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">{% endif %}
 
-	<title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+	<title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
 
         <link href="{{ base_url }}/css/bootstrap-custom.min.css" rel="stylesheet">
         <link href="{{ base_url }}/css/font-awesome-4.5.0.css" rel="stylesheet">
@@ -26,25 +26,25 @@
             <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
 
-        {% if google_analytics %}
+        {% if config.google_analytics %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', '{{ google_analytics[0] }}', '{{ google_analytics[1] }}');
+            ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
             ga('send', 'pageview');
         </script>
         {% endif %}
     </head>
 
-    <body{% if current_page and current_page.is_homepage %} class="homepage"{% endif %}>
+    <body{% if page and page.is_homepage %} class="homepage"{% endif %}>
 
         {% include "nav.html" %}
         <div class="container">
             {% block content %}
-                {% if current_page and not current_page.is_homepage %}
+                {% if page and not page.is_homepage %}
                 <div class="col-md-3">{% include "toc.html" %}</div>
                 {% endif %}
                 <div class="col-md-9" role="main">{% include "content.html" %}</div>
@@ -57,8 +57,8 @@
                     <p>All code on this site is licensed under the <a href="https://github.com/screwdriver-cd/screwdriver/blob/master/LICENSE">Yahoo BSD License</a> unless otherwise stated.</p>
                 </div>
                 <div class="col-xs-6">
-                    {% if copyright %}
-                        <p>{{ copyright }}</p>
+                    {% if config.copyright %}
+                        <p>{{ config.copyright }}</p>
                     {% endif %}
                 </div>
             </div>
@@ -101,7 +101,7 @@
 
     </body>
 </html>
-{% if current_page and current_page.is_homepage %}
+{% if page and page.is_homepage %}
 <!--
 MkDocs version : {{ mkdocs_version }}
 Build Date UTC : {{ build_date_utc }}

--- a/themes/sd/nav.html
+++ b/themes/sd/nav.html
@@ -3,7 +3,7 @@
 
         <!-- Collapsed navigation -->
         <div class="navbar-header">
-            {% if include_nav or include_next_prev or repo_url %}
+            {% if nav|length>1 or (page.next_page or page.previous_page) or config.repo_url %}
             <!-- Expander button -->
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                 <span class="sr-only">Toggle navigation</span>
@@ -14,7 +14,7 @@
             {% endif %}
 
             <!-- Main title -->
-            <a class="navbar-brand" href="{{ homepage_url }}">{{ site_name }}</a>
+            <a class="navbar-brand" href="{{ nav.homepage.url }}">{{ config.site_name }}</a>
         </div>
 
         <!-- Expanded navigation -->
@@ -25,22 +25,22 @@
                         <i class="fa fa-search"></i> Search
                     </a>
                 </li>
-                {% if repo_url %}
+                {% if config.repo_url %}
                     <li>
-                        <a href="{{ repo_url }}">
-                            {% if repo_name == 'GitHub' %}
+                        <a href="{{ config.repo_url }}">
+                            {% if config.repo_name == 'GitHub' %}
                                 <i class="fa fa-github"></i>
-                            {% elif repo_name == 'Bitbucket' %}
+                            {% elif config.repo_name == 'Bitbucket' %}
                                 <i class="fa fa-bitbucket"></i>
                             {% endif %}
-                            {{ repo_name }}
+                            {{ config.repo_name }}
                         </a>
                     </li>
                 {% endif %}
             </ul>
         </div>
         <div class="navbar-collapse collapse">
-            {% if include_nav %}
+            {% if nav|length>1 %}
                 <!-- Main navigation -->
                 <ul class="nav navbar-nav">
                 {% for nav_item in nav %}

--- a/themes/sd/toc.html
+++ b/themes/sd/toc.html
@@ -1,6 +1,6 @@
 <div class="bs-sidebar hidden-print affix well" role="complementary">
     <ul class="nav bs-sidenav">
-    {% for toc_item in toc %}
+    {% for toc_item in page.toc %}
         <li class="main {% if toc_item.active %}active{% endif %}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
         {% for toc_item in toc_item.children %}
             <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>


### PR DESCRIPTION
It tweaks to migrate to new variable names and expressions for MkDocs v0.16.

It also includes following changes.

* Use `config.site_description` instead of `page_description`
* Use `config.site_author` instead of `site_author`
* Use `page.canonical_url` instead of `canonical_url`
* Use `config.favicon` instead of `favicon`
* Use `page.title` instead of `page_title`
* Use `config.google_analytics` instead of `google_analytics`
* Use `page` instead of `current_page`
* Use `config.copyright` instead of `copyright`
* Use `page.meta` instead of `meta`
* Use `page.content` instead of `content`
* Use `nav|length>1` instead of `include_nav`
* Use `(page.next_page or page.previous_page)` instead of `include_next_prev`
* Use `config.repo_url` instead of `repo_url`
* Use `nav.homepage.url` instead of `homepage_url`
* Use `config.site_name` instead of `site_name`
* Use `config.repo_name` instead of `repo_name`
* Use `page.toc` instead of `toc`
* Rename `themes/sd/base.html` to `themes/sd/main.html`

See also: http://www.mkdocs.org/about/release-notes/#version-016-2016-11-04

I've verified it works on locally.