### PR TITLE
fix: Document step name restrictions, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,26 +74,36 @@ Simply add a new markdown document to the folder hierarchy in `docs`, and add an
 ## Documentation Structure
 
 - Homepage
-   - [ ] What are the sections for
-- Cluster Management
-   - [x] Overall Architecture
-   - [ ] Running Locally
-   - [x] Configuring API + plugins
-   - [x] Configuring UI
-   - [x] Configuring Store + plugins
-   - [ ] Debugging
-- Using Screwdriver
-   - [ ] Getting Started
-   - [x] Setting up the SD yaml + secrets
-   - [x] API/documentation page
-   - [x] Authentication and Authorization
+  - [x] What are the sections for
+- Cluster Management (for SD owners)
+  - [x] Overall architecture
+  - [x] Running locally
+  - [x] Configuring API
+     - [x] Scm plugins
+     - [x] Datastore plugins
+  - [x] Configuring UI
+  - [x] Configuring Store
+     - [x] Logging plugins
+  - Examples
+    - [x] Setting up Kubernetes
+  - [ ] Debugging
+- User Guide
+  - [x] Quickstart
+  - [x] Configuration
+    - [x] Overall YAML
+    - [x] Secrets
+  - [x] API
+  - [x] Authentication and Authorization
 - About
-   - Appendix
-     - [ ] What is SD?
-     - [x] Domain model
-   - Support
+  - [x] What is SD?
+  - [x] Appendix
+    - [x] Execution engines
+    - [x] Domain model
+  - [x] Contributing
+  - [x] Support
 
-[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/guide.svg
-[issues-url]: https://github.com/screwdriver-cd/guide/issues
-[status-image]: https://cd.screwdriver.cd/pipelines/baa6a0374df961ac97669bf3a3089a24cfb72794/badge
-[status-url]: https://cd.screwdriver.cd/pipelines/baa6a0374df961ac97669bf3a3089a24cfb72794
+
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver.svg
+[issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
+[status-image]: https://cd.screwdriver.cd/pipelines/27/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/27

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -72,7 +72,7 @@ You can access information about properties by hovering over the property name.
         </div>
         <div id="steps" class="hidden">
             <h4>Steps</h4>
-            <p>Defines the explicit list of commands that are executed in the build, just as if they were entered on the command line. Step definitions are required for all jobs.</p>
+            <p>Defines the explicit list of commands that are executed in the build, just as if they were entered on the command line. Step definitions are required for all jobs. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps.</p>
         </div>
     </div>
 </div>

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -61,7 +61,7 @@ The `jobs` section is where all the tasks (or `steps`) that each job will execut
 ### Steps
 The `steps` section contains a list of commands to execute.
 Each step takes the form "step_name: command_to_run". The "step_name" is a convenient label to reference it by. The
-"command_to_run" is the single command that is executed during this step.
+"command_to_run" is the single command that is executed during this step. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps.
 
 In our example, our "main" job executes a simple piece of inline bash code. We also define another job called "second_job". In this job, we intend on running a different set of commands. The "make_target" step calls a Makefile target to perform some set of actions. This is incredibly useful when you need to perform a multi-line command.
 The "run_arbitrary_script" executes a script. This is an alternative to a Makefile target where you want to run a series of commands related to this step.


### PR DESCRIPTION
- step names cannot start with `sd-`
- updating guide structure
- updating Screwdriver pipeline badge links