### PR TITLE
Update links to Kuberenetes api.yaml file to point to different repo

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -65,7 +65,6 @@ The object models provide the definition of the data that is stored in data stor
 A datastore implementation is used as the interface between the API and a data storage mechanism. There are several implementations written in node around a common interface.
 
 * **[datastore-base][datastore-base-repo]**: Common interface [![Version][datastore-base-npm-image]][datastore-base-npm-url]
-* **[datastore-dynamodb][datastore-dynamodb-repo]**: DynamoDB implementation [![Version][datastore-dynamodb-npm-image]][datastore-dynamodb-npm-url]
 * **[datastore-sequelize][datastore-sequelize-repo]**: Mysql, postgres, sqlite3 and mssql implementation [![Version][datastore-sequelize-npm-image]][datastore-sequelize-npm-url]
 
 ### Scms
@@ -132,10 +131,6 @@ We have some tools to help start out new repos for screwdriver:
 [datastore-base-repo]: https://github.com/screwdriver-cd/datastore-base
 [datastore-base-npm-image]: https://img.shields.io/npm/v/screwdriver-datastore-base.svg
 [datastore-base-npm-url]: https://npmjs.org/package/screwdriver-datastore-base
-
-[datastore-dynamodb-repo]: https://github.com/screwdriver-cd/datastore-dynamodb
-[datastore-dynamodb-npm-image]: https://img.shields.io/npm/v/screwdriver-datastore-dynamodb.svg
-[datastore-dynamodb-npm-url]: https://npmjs.org/package/screwdriver-datastore-dynamodb
 
 [datastore-sequelize-repo]: https://github.com/screwdriver-cd/datastore-sequelize
 [datastore-sequelize-npm-image]: https://img.shields.io/npm/v/screwdriver-datastore-sequelize.svg

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -96,28 +96,7 @@ ecosystem:
 
 ### Datastore Plugin
 
-To use DynamoDB, use [dynamodb](https://github.com/screwdriver-cd/datastore-dynamodb) plugin. To use Postgres, MySQL, and Sqlite, use [sequelize](https://github.com/screwdriver-cd/datastore-sequelize) plugin.
-
-#### DynamoDB
-Set these environment variables:
-
-| Environment name          | Required | Default Value     | Description                          |
-|:--------------------------|:---------|:------------------|:-------------------------------------|
-| DATASTORE_PLUGIN          | Yes      |                   | Set to `dynamodb`                    |
-| DATASTORE_DYNAMODB_PREFIX | No       | '' (empty string) | Prefix to add before all table names |
-| DATASTORE_DYNAMODB_ID     | Yes      |                   | AWS Access Key Id                    |
-| DATASTORE_DYNAMODB_SECRET | Yes      |                   | AWS Secret Access Key                |
-
-```yaml
-# config/local.yaml
-datastore:
-    plugin: dynamodb
-    dynamodb:
-        # Prefix to the table names
-        prefix: TABLE-PREFIX
-        accessKeyId: AWS-ACCESS-KEY-ID
-        secretAccessKey: AWS-SECRET-ACCESS-KEY
-```
+To use Postgres, MySQL, and Sqlite, use [sequelize](https://github.com/screwdriver-cd/datastore-sequelize) plugin.
 
 #### Sequelize
 Set these environment variables:

--- a/docs/cluster-management/index.md
+++ b/docs/cluster-management/index.md
@@ -64,9 +64,9 @@ built/maintained by Screwdriver:
  - **Execution Engine**
 
     Pluggable build executor that supports executing commands inside of a
-    container (e.g. Jenkins, Kubernetes, and Mesos).
+    container (e.g. Jenkins, Kubernetes, and Docker).
 
  - **Datastore**
 
-    Pluggable NoSQL-based storage for keeping information about pipelines
-    (e.g. DynamoDB, MongoDB, and CouchDB).
+    Pluggable storage for keeping information about pipelines
+    (e.g. Postgres, MySQL, and Sqlite).

--- a/docs/cluster-management/kubernetes.md
+++ b/docs/cluster-management/kubernetes.md
@@ -111,13 +111,13 @@ Other environment variables can also be customized for Screwdriver. For a full l
 
 
 ## Deploy Screwdriver
-You can check out the `api.yaml` in the [Screwdriver Kubernetes repo](https://github.com/screwdriver-cd/kubernetes) for service and deployment definitions to run the Screwdriver API.
+You can check out the `api.yaml` in the [Screwdriver config examples repo](https://github.com/screwdriver-cd-test/config-examples) for service and deployment definitions to run the Screwdriver API.
 
 ### Create a Service
 A Kubernetes Service is an abstraction which defines a set of Pods and is assigned a unique IP address which persists.
 Follow instructions in [Creating a Service](http://kubernetes.io/docs/user-guide/connecting-applications/#creating-a-service) to set up your `service.yaml`.
 
-It should look like the Service in [api.yaml](https://github.com/screwdriver-cd/kubernetes/blob/master/api.yaml).
+It should look like the Service in [api.yaml](https://github.com/screwdriver-cd-test/config-examples/blob/master/kubernetes/api.yaml).
 
 To create your service, run the `kubectl create` command on your `service.yaml` file:
 ```bash
@@ -152,7 +152,7 @@ $ kubectl describe services sdapi
 ### Create a Deployment
 A Deployment makes sure a specified number of pod “replicas” are running at any one time. If there are too many, it will kill some; if there are too few, it will start more. Follow instructions on the [Deploying Applications](http://kubernetes.io/docs/user-guide/deploying-applications/) page to create your `deployment.yaml`.
 
-It should look like the Deployment in [api.yaml](https://github.com/screwdriver-cd/kubernetes/blob/master/api.yaml).
+It should look like the Deployment in [api.yaml](https://github.com/screwdriver-cd-test/config-examples/blob/master/kubernetes/api.yaml).
 
 ### Deploy
 For a fresh deployment, run the `kubectl create` command on your `deployment.yaml` file:


### PR DESCRIPTION
- [x] Moved Kubernetes example configs over to the `example-configs` repo, updating links in the guide to match
- [x] Removed dynamodb references
- [x] Update Kubernetes cluster setup doc

Blocked by https://github.com/screwdriver-cd-test/config-examples/pull/3