### PR TITLE
feat: extending a docker image

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -1,4 +1,4 @@
-## Managing the API
+# Managing the API
 
 ## Packages
 
@@ -47,6 +47,26 @@ auth:
         - robin
     admins:
         - batman
+```
+
+### Bookend Plugins
+
+You can globally configure which built-in bookend plugins will be used during a build. By default, `sd-scm` is enabled to begin builds with a SCM checkout command.
+
+If you're looking to include a custom bookend in the API, please refer to the *Using a custom bookend* topic in the *Extending the Docker container* section.
+
+| Key | Default| Description |
+|:----|:-------|:------------|
+| BOOKENDS_SETUP | None | The ordered list of plugins to execute at the beginning of every build. Take the forms of `'["first", "second", ...]'` |
+| BOOKENDS_TEARDOWN | None | The ordered list of plugins to execute at the end of every build. Take the forms of `'["first", "second", ...]'` |
+
+
+```yaml
+# config/local.yaml
+ecosystem:
+    setup:
+        - sd-scm
+        - my-custom-bookend
 ```
 
 ### Serving
@@ -224,4 +244,58 @@ scm:
     bitbucket:
         oauthClientId: YOUR-APP-KEY
         oauthClientSecret: YOUR-APP-SECRET
+```
+
+## Extending the Docker container
+
+There are some scenarios where you would prefer to extend the ScrewdriverCD Docker image, such as using custom Bookend plugins. This section is not meant to be exhaustive or complete, but will provide insight into some of the fundamental cases.
+
+### Using a custom bookend
+
+Using a custom bookend is a common case where you would extend the ScrewdriverCD Docker image.
+
+In this chosen example, we want to have our bookend execute before the `sd-scm` (which checks out the code from the configured SCM). Although the bookend plugins can be configured by environment variables, we will show how to accomplish the same task with a `local.yaml` file.
+
+This is shown in the following `local.yaml` snippet:
+
+```
+# local.yaml
+---
+  ...
+ecosystem:
+  setup:
+    - my-custom-bookend
+    - sd-scm
+```
+
+For building our extended Docker image, we will need to create a `Dockerfile` that will have our extra dependencies installed. If you would prefer to save the `local.yaml` configuration file in the Docker image instead of mounting it in later, you may do so in the Dockerfile as well.
+
+```yaml
+# Dockerfile
+
+FROM screwdrivercd/screwdriver:stable
+
+# Install additional NPM bookend plugin
+RUN cd /usr/src/app && /usr/local/bin/npm install my-custom-bookend
+
+# Optionally save the configuration file in the image
+# ADD local.yaml /usr/src/app/node_modules/screwdriver-api/config/local.yaml
+```
+
+Once you build the Docker image, you will need to deploy it to your ScrewdriverCD cluster. For instance, if you're using Kubernetes, you would replace the `screwdrivercd/api:stable` image to your custom Docker image.
+
+The following is an example snippet of an updated Kubernetes deployment configuration:
+
+```
+# partial Kubernetes configuration
+  ...
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: screwdriver-api
+        # The image name is the one you specified when built
+        # The tag name is the tag you specified when built
+        image: my_extended_docker_image_name:tag_name
 ```

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -51,9 +51,9 @@ auth:
 
 ### Bookend Plugins
 
-You can globally configure which built-in bookend plugins will be used during a build. By default, `sd-scm` is enabled to begin builds with a SCM checkout command.
+You can globally configure which built-in bookend plugins will be used during a build. By default, `scm` is enabled to begin builds with a SCM checkout command.
 
-If you're looking to include a custom bookend in the API, please refer to the *Using a custom bookend* topic in the *Extending the Docker container* section.
+If you're looking to include a custom bookend in the API, please refer [here](#extending-the-docker-container).
 
 | Key | Default| Description |
 |:----|:-------|:------------|
@@ -63,9 +63,9 @@ If you're looking to include a custom bookend in the API, please refer to the *U
 
 ```yaml
 # config/local.yaml
-ecosystem:
+bookends:
     setup:
-        - sd-scm
+        - scm
         - my-custom-bookend
 ```
 
@@ -248,45 +248,44 @@ scm:
 
 ## Extending the Docker container
 
-There are some scenarios where you would prefer to extend the ScrewdriverCD Docker image, such as using custom Bookend plugins. This section is not meant to be exhaustive or complete, but will provide insight into some of the fundamental cases.
+There are some scenarios where you would prefer to extend the Screwdriver.cd Docker image, such as using custom Bookend plugins. This section is not meant to be exhaustive or complete, but will provide insight into some of the fundamental cases.
 
 ### Using a custom bookend
 
-Using a custom bookend is a common case where you would extend the ScrewdriverCD Docker image.
+Using a custom bookend is a common case where you would extend the Screwdriver.cd Docker image.
 
-In this chosen example, we want to have our bookend execute before the `sd-scm` (which checks out the code from the configured SCM). Although the bookend plugins can be configured by environment variables, we will show how to accomplish the same task with a `local.yaml` file.
+In this chosen example, we want to have our bookend execute before the `scm` (which checks out the code from the configured SCM). Although the bookend plugins can be configured by environment variables, we will show how to accomplish the same task with a `local.yaml` file.
 
 This is shown in the following `local.yaml` snippet:
 
-```
+```yaml
 # local.yaml
 ---
   ...
-ecosystem:
+bookends:
   setup:
     - my-custom-bookend
-    - sd-scm
+    - scm
 ```
 
 For building our extended Docker image, we will need to create a `Dockerfile` that will have our extra dependencies installed. If you would prefer to save the `local.yaml` configuration file in the Docker image instead of mounting it in later, you may do so in the Dockerfile as well.
 
-```yaml
+```dockerfile
 # Dockerfile
-
 FROM screwdrivercd/screwdriver:stable
 
 # Install additional NPM bookend plugin
 RUN cd /usr/src/app && /usr/local/bin/npm install my-custom-bookend
 
 # Optionally save the configuration file in the image
-# ADD local.yaml /usr/src/app/node_modules/screwdriver-api/config/local.yaml
+ADD local.yaml /config/local.yaml
 ```
 
-Once you build the Docker image, you will need to deploy it to your ScrewdriverCD cluster. For instance, if you're using Kubernetes, you would replace the `screwdrivercd/api:stable` image to your custom Docker image.
+Once you build the Docker image, you will need to deploy it to your Screwdriver.cd cluster. For instance, if you're using Kubernetes, you would replace the `screwdrivercd/api:stable` image to your custom Docker image.
 
 The following is an example snippet of an updated Kubernetes deployment configuration:
 
-```
+```yaml
 # partial Kubernetes configuration
   ...
 spec:


### PR DESCRIPTION
# Additional topics

Added documentation on how you can modify the bookend plugins to change the order of the built-in plugins. It also refers to custom plugins that are written in a different section.

Added documentation on how to use the API Docker image as a base and build on top of it, such as including custom dependencies.

![screen shot 2017-01-30 at 17 21 48](https://cloud.githubusercontent.com/assets/622065/22448789/94176636-e710-11e6-8dcb-53cef9c91094.png)
