### PR TITLE
fix: Add launcher environment variable passing to docs

### DIFF
--- a/docs/about/appendix/domain.md
+++ b/docs/about/appendix/domain.md
@@ -9,7 +9,7 @@ Source Code is a specified SCM repository and branch that contains a `screwdrive
 
 ### Step
 
-A step is a named action that needs to be performed, usually a single shell command. If the command finishes with a non-zero exit code, the step is considered a failure.
+A step is a named action that needs to be performed, usually a single shell command. In essence, Screwdriver runs `/bin/sh` in your terminal then executes all the steps; in rare cases, different terminal/shell setups may have unexpected behavior. If the command finishes with a non-zero exit code, the step is considered a failure. Environment variables will be passed between steps, within the same job.
 
 ### Container
 

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -72,7 +72,7 @@ You can access information about properties by hovering over the property name.
         </div>
         <div id="steps" class="hidden">
             <h4>Steps</h4>
-            <p>Defines the explicit list of commands that are executed in the build, just as if they were entered on the command line. Step definitions are required for all jobs. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps.</p>
+            <p>Defines the explicit list of commands that are executed in the build, just as if they were entered on the command line. Environment variables will be passed between steps, within the same job. Step definitions are required for all jobs. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps. In essence, Screwdriver runs `/bin/sh` in your terminal then executes all the steps; in rare cases, different terminal/shell setups may have unexpected behavior.</p>
         </div>
     </div>
 </div>

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -61,9 +61,11 @@ The `jobs` section is where all the tasks (or `steps`) that each job will execut
 ### Steps
 The `steps` section contains a list of commands to execute.
 Each step takes the form "step_name: command_to_run". The "step_name" is a convenient label to reference it by. The
-"command_to_run" is the single command that is executed during this step. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps.
+"command_to_run" is the single command that is executed during this step. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps. Environment variables will be passed between steps, within the same job. In essence, Screwdriver runs `/bin/sh` in your terminal then executes all the steps; in rare cases, different terminal/shell setups may have unexpected behavior.
 
-In our example, our "main" job executes a simple piece of inline bash code. We also define another job called "second_job". In this job, we intend on running a different set of commands. The "make_target" step calls a Makefile target to perform some set of actions. This is incredibly useful when you need to perform a multi-line command.
+In our example, our "main" job executes a simple piece of inline bash code. The first step (`export`) exports an environment variable, `GREETING="Hello, world!"`. The second step (`hello`) echoes the environment variable from the first step.
+
+We also define another job called "second_job". In this job, we intend on running a different set of commands. The "make_target" step calls a Makefile target to perform some set of actions. This is incredibly useful when you need to perform a multi-line command.
 The "run_arbitrary_script" executes a script. This is an alternative to a Makefile target where you want to run a series of commands related to this step.
 
 ```yaml
@@ -73,7 +75,8 @@ jobs:
   main:
     # Steps definition block.
     steps:
-      - hello: echo hi world
+      - export: export GREETING="Hello, world!"
+      - hello: echo $GREETING
   second_job:
     steps:
       - make_target: make greetings


### PR DESCRIPTION
Added explanations of environment variables passed from step to step within jobs to the following parts of the Docs:

- [x] Domain Model
- [x] User Guide - Configuration (YAML)
- [x] Quickstart Guide (also changed quickstart-generic example to include environment variable passing)
- [x] Updated generic quickstart screwdriver.yaml with an example of this behavior: https://github.com/screwdriver-cd-test/quickstart-generic/pull/5

Related to https://github.com/screwdriver-cd/screwdriver/issues/393