### PR TITLE
fix: Use meta instead of /opt/sd/meta

### DIFF
--- a/docs/about/appendix/domain.md
+++ b/docs/about/appendix/domain.md
@@ -81,10 +81,10 @@ Metadata is a structured key/value storage of relevant information about a [buil
 
 Example:
 ```bash
-$ /opt/sd/meta set meta.coverage 99.95
-$ /opt/sd/meta get meta.coverage
+$ meta set example.coverage 99.95
+$ meta get example.coverage
 99.95
-$ /opt/sd/meta get meta
+$ meta get example
 {"coverage":99.95}
 ```
 


### PR DESCRIPTION
There is a symlink now. Thanks to https://github.com/screwdriver-cd/launcher/pull/111

Change `meta` to `example` to reduce confusion. 