### PR TITLE
fix docker hub repository name

### DIFF
--- a/docs/cluster-management/running-locally.md
+++ b/docs/cluster-management/running-locally.md
@@ -42,13 +42,13 @@ Here is a snippet of the `docker-compose.yml` file
 version: '2'
 services:
   api:
-    image: screwdriver-cd/screwdriver:stable
+    image: screwdrivercd/screwdriver:stable
     . . .
   ui:
-    image: screwdriver-cd/ui:stable
+    image: screwdrivercd/ui:stable
     . . .
   store:
-    image: screwdriver-cd/store:stable
+    image: screwdrivercd/store:stable
     . . .
 ```
 


### PR DESCRIPTION
The images are available on [docker hub](https://hub.docker.com/r/screwdrivercd/screwdriver/) under the repository screwdrivercd. The doc looks for screwdriver-cd. 