### PR TITLE
fix(470): Add job template docs

### DIFF
--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -1,0 +1,89 @@
+# Templates
+
+Templates are snippets of predefined code that people can use to replace a job definition in a [screwdriver.yaml](./configuration/index.md). A template contains a series of predefined steps along with a selected Docker image.
+
+## Using a template
+
+To use a template, define a `screwdriver.yaml`:
+
+```yaml
+jobs:
+   main:
+      template: template_name@1.3.0
+```
+
+Screwdriver takes the template configuration and plugs it in, so that the `screwdriver.yaml` becomes:
+
+```yaml
+jobs:
+   main:
+        image: node:6
+        steps:
+          - install: npm install
+          - test: npm test
+          - echo: echo $FOO
+        environment:
+           FOO: bar
+        secrets:
+          - NPM_TOKEN
+```
+
+## Creating a template
+
+### Writing a template yaml
+
+To create a template, create a new repo with a `screwdriver-template.yaml` file. The file should contain a name, version, description, maintainer email, and a config with an image and steps.
+
+Example `screwdriver-template.yaml`:
+
+```yaml
+name: template_name
+version: '1.3'
+description: template for testing
+maintainer: foo@bar.com
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN
+```
+
+### Writing a screwdriver.yaml for your template repo
+
+To validate your template, run the `template-validate` script from the `screwdriver-template-main` npm module in your `main` job to validate your template. To publish your template, run the `template-publish` script from the same module in a separate job.
+
+By default, the file at `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+Example `screwdriver.yaml`:
+
+```yaml
+shared:
+    image: node:6
+jobs:
+    # the main job is run in pull requests as well
+    main:
+        steps:
+            - install: npm install screwdriver-template-main
+            - validate: ./node_modules/.bin/template-validate
+        environment:
+            SD_TEMPLATE_PATH: ./path/to/template.yaml
+    publish:
+        steps:
+            - install: npm install screwdriver-template-main
+            - publish: ./node_modules/.bin/template-publish
+        environment:
+            SD_TEMPLATE_PATH: ./path/to/template.yaml
+```
+
+Create a Screwdriver pipeline with your template repo and start the build to validate and publish it.
+
+To update a Screwdriver template, make changes in your SCM repository and rerun the pipeline build.
+
+## Finding templates
+
+To figure out which templates already exist, you can make a `GET` call to the `/templates` endpoint. See the [API documentation](./api.md) for more information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,12 +23,13 @@ pages:
             - Kubernetes: 'cluster-management/kubernetes.md'
     - User Guide:
         - Quickstart: 'user-guide/quickstart.md'
+        - API: 'user-guide/api.md'
         - Authentication and Authorization: 'user-guide/authentication-authorization.md'
         - Configuration:
             - Overall: 'user-guide/configuration/index.md'
             - Secrets: 'user-guide/configuration/secrets.md'
         - Environment Variables: 'user-guide/environment-variables.md'
-        - API: 'user-guide/api.md'
+        - Templates: 'user-guide/templates.md'
         - FAQ: 'user-guide/FAQ.md'
     - About:
         - What is Screwdriver?: 'about/index.md'


### PR DESCRIPTION
It would be good to conduct a user observation or two on our templates feature. This PR adds documentation for creating a job template, using a job template, and finding job templates.

![screencapture-127-0-0-1-8000-user-guide-templates-1499454362540](https://user-images.githubusercontent.com/3230529/27972873-b69bcbca-630c-11e7-9a59-3adfcdae26d6.png)

_Not sure if there's any information missing here._

Related issue: https://github.com/screwdriver-cd/screwdriver/issues/470