### PR TITLE
fix: Add metadata page to User Guide section

### DIFF
--- a/docs/about/appendix/domain.md
+++ b/docs/about/appendix/domain.md
@@ -77,7 +77,7 @@ An event represents a commit or a manual restart of a [pipeline]. There are 2 ty
 
 ### Metadata
 
-Metadata is a structured key/value storage of relevant information about a [build]. Metadata will be shared with subsequent builds in the same [workflow]. It can be updated or retrieved throughout the build by using the built-in CLI ([meta](https://github.com/screwdriver-cd/meta-cli)) in the [steps].
+Metadata is a structured key/value storage of relevant information about a [build]. Metadata will be shared with subsequent builds in the same [workflow]. It can be updated or retrieved throughout the build by using the built-in [meta CLI](https://github.com/screwdriver-cd/meta-cli) in the [steps].
 
 Example:
 ```bash
@@ -87,6 +87,8 @@ $ meta get example.coverage
 $ meta get example
 {"coverage":99.95}
 ```
+
+See the [metadata page](../../user-guide/configuration/metadata.md) for more information.
 
 ### Workflow
 

--- a/docs/user-guide/configuration/metadata.md
+++ b/docs/user-guide/configuration/metadata.md
@@ -1,0 +1,25 @@
+# Metadata
+
+## What is Metadata?
+
+Metadata is a structured key/value storage of relevant information about a [build](../../about/appendix/domain#build). Metadata will be shared with subsequent builds in the same [workflow](../../about/appendix/domain#workflow). It can be updated or retrieved throughout the build by using the built-in [meta CLI](https://github.com/screwdriver-cd/meta-cli) in the [steps](../../about/appendix/domain#step).
+
+## Manipulating Metadata
+
+Screwdriver provides the shell command `meta get` to extract information from the meta store and `meta set` to save information to the meta store.
+
+Example:
+```bash
+$ meta set example.coverage 99.95
+$ meta get example.coverage
+99.95
+$ meta get example
+{"coverage":99.95}
+```
+
+Example:
+```bash
+$ meta set foo[2].bar[1] baz
+$ meta get foo
+[null,null,{"bar":[null,"baz"]}]
+```

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -2,6 +2,8 @@
 
 Screwdriver exports a set of environment variables that you can rely on during the course of a build.
 
+_Note: Environment variables set in one job cannot be accessed in another job. To pass variables between jobs, use [metadata](./configuration/metadata.md)._
+
 ## Build Specific
 | Name | Value |
 |------|-------|

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -18,7 +18,7 @@ $ git clone git@github.com:<YOUR_USERNAME_HERE>/quickstart-generic.git
 $ cd quickstart-generic/
 ```
 
-*For applications that are better suited to Makefiles and small scripts, we recommend referencing the generic `screwdriver.yaml`.
+*For applications that are better suited to Makefiles and small scripts, we recommend referencing the generic `screwdriver.yaml`.*
 
 ## Developing the App
 
@@ -63,7 +63,7 @@ The `steps` section contains a list of commands to execute.
 Each step takes the form "step_name: command_to_run". The "step_name" is a convenient label to reference it by. The
 "command_to_run" is the single command that is executed during this step. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps. Environment variables will be passed between steps, within the same job. In essence, Screwdriver runs `/bin/sh` in your terminal then executes all the steps; in rare cases, different terminal/shell setups may have unexpected behavior.
 
-In our example, our "main" job executes a simple piece of inline bash code. The first step (`export`) exports an environment variable, `GREETING="Hello, world!"`. The second step (`hello`) echoes the environment variable from the first step.
+In our example, our "main" job executes a simple piece of inline bash code. The first step (`export`) exports an environment variable, `GREETING="Hello, world!"`. The second step (`hello`) echoes the environment variable from the first step. The third step uses [metadata](./configuration/metadata.md), a structured key/value storage of relevant information about a build, to set an arbitrary key in the "main" job and get it in the "second_job".
 
 We also define another job called "second_job". In this job, we intend on running a different set of commands. The "make_target" step calls a Makefile target to perform some set of actions. This is incredibly useful when you need to perform a multi-line command.
 The "run_arbitrary_script" executes a script. This is an alternative to a Makefile target where you want to run a series of commands related to this step.
@@ -77,9 +77,11 @@ jobs:
     steps:
       - export: export GREETING="Hello, world!"
       - hello: echo $GREETING
+      - set-metadata: meta set example.coverage 99.95
   second_job:
     steps:
       - make_target: make greetings
+      - get-metadata: meta get example
       - run_arbitrary_script: ./my_script.sh
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ pages:
         - Authentication and Authorization: 'user-guide/authentication-authorization.md'
         - Configuration:
             - Overall: 'user-guide/configuration/index.md'
+            - Metadata: 'user-guide/configuration/metadata.md'
             - Secrets: 'user-guide/configuration/secrets.md'
         - Environment Variables: 'user-guide/environment-variables.md'
         - Templates: 'user-guide/templates.md'


### PR DESCRIPTION
- Add Metadata page
- Add metadata example to Quickstart
- Link to Metadata page in Environment Variable page