### PR TITLE
fix(564): Add warning that some features have not been implemented yet

### DIFF
--- a/docs/about/appendix/domain.md
+++ b/docs/about/appendix/domain.md
@@ -1,5 +1,7 @@
 ## Domain Model
 
+_Note: `Parallel`, `series`, and `matrix` have not been implemented yet. Everything will run in series by default._
+
 ![Definition](assets/definition-model.png)
 ![Runtime](assets/runtime-model.png)
 
@@ -92,7 +94,7 @@ See the [metadata page](../../user-guide/configuration/metadata.md) for more inf
 
 ### Workflow
 
-Workflow is the order that [jobs] will execute in after a successful [build] of the `main` job on the default branch. Jobs can be executed in parallel, series, or a combination of the two to allow for all possibilities. Workflow must contain all defined jobs in the pipeline.
+Workflow is the order that [jobs] will execute in after a successful [build] of the `main` job. The `main` job will always run first. Jobs can be executed in parallel, series, or a combination of the two to allow for all possibilities. Workflow must contain all defined jobs in the pipeline.
 
 All jobs executed in a given workflow share:
 

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -4,6 +4,8 @@ This is an interactive guide for exploring various important properties of the s
 
 You can access information about properties by hovering over the property name.
 
+_Note: `Parallel`, `series`, and `matrix` have not been implemented yet. Everything will run in series by default._
+
 <div class="yaml-docs">
 
 <pre class="example">


### PR DESCRIPTION
## Context

There's documentation for features such as `parallel`, `series`, and `matrix` in the guide that are not actually implemented yet.

## Objective

This PR adds a warning on the relevant pages.

## Relevant Links

Resolves https://github.com/screwdriver-cd/screwdriver/issues/564