### PR TITLE
fix: fix sd-step argument

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,12 +3,12 @@
 source ./ci/git-ssh.sh
 mkdir _deploy
 cd _deploy
-sd-step exec git 'git clone -b gh-pages git@github.com:screwdriver-cd/guide.git'
+sd-step exec core/git 'git clone -b gh-pages git@github.com:screwdriver-cd/guide.git'
 cd guide
 rm -rf *
 cp -R ../../_site/* .
-sd-step exec git 'git add -A'
-sd-step exec git 'git commit -m "Deployed by Screwdriver"'
-sd-step exec git 'git push origin gh-pages'
+sd-step exec core/git 'git add -A'
+sd-step exec core/git 'git commit -m "Deployed by Screwdriver"'
+sd-step exec core/git 'git push origin gh-pages'
 cd ../..
 rm -rf _deploy


### PR DESCRIPTION
To use git command via sd-step, we have to designate `core/git` instead of `git` in sd-step arguments.