### PR TITLE
fix(687): Add Slack notifications settings for user and cluster admin

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -71,7 +71,7 @@ The **[screwdriver][api-repo]** repo is the core of screwdriver, providing the A
 
 
 * **[Build bookends][build-bookend-repo]** allow a user to create setup and teardown steps for builds.
-* The API can also send notifications to users. [notifications-base][notifications-base-repo] is the base class for defining the behavior between screwdriver and notifications plugins, like [email notifications][notifications-email-repo].
+* The API can also send notifications to users. [notifications-base][notifications-base-repo] is the base class for defining the behavior between screwdriver and notifications plugins, like [email notifications][notifications-email-repo] and [slack notifications][notifications-slack-repo].
 
 ### [Launcher][launcher-repo]
 
@@ -196,6 +196,7 @@ The organization [screwdriver-cd-test][screwdriver-cd-test-org] contains various
 [models-repo]: https://github.com/screwdriver-cd/models
 [notifications-base-repo]: https://github.com/screwdriver-cd/notifications-base
 [notifications-email-repo]: https://github.com/screwdriver-cd/notifications-email
+[notifications-slack-repo]: https://github.com/screwdriver-cd/notifications-slack
 [scm-base-repo]: https://github.com/screwdriver-cd/scm-base
 [scm-bitbucket-repo]: https://github.com/screwdriver-cd/scm-bitbucket
 [scm-github-repo]: https://github.com/screwdriver-cd/scm-github

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -209,7 +209,7 @@ executor:
             launchVersion: stable
 ```
 ### Notifications Plugin
-We currently support [Email notifications](https://github.com/screwdriver-cd/notifications-email).
+We currently support [Email notifications](https://github.com/screwdriver-cd/notifications-email) and [Slack notifications](https://github.com/screwdriver-cd/notifications-slack).
 
 #### Email Notifications
 
@@ -225,6 +225,17 @@ notifications:
 ```
 
 Configurable authentication settings have not yet been built, but can easily be added. We’re using the [nodemailer](https://nodemailer.com/about/) package to power emails, so authentication features will be similar to any typical nodemailer setup. Contribute at: [screwdriver-cd/notifications-email](https://github.com/screwdriver-cd/notifications-email)
+
+#### Slack Notifications
+
+Create a `screwdriver-bot` user in your Slack instance. Generate a Slack token for the new user and set it in your Slack notifications settings.
+
+```yaml
+# config/local.yaml
+notifications:
+    slack:
+        token: 'YOUR-SLACK-USER-TOKEN-HERE'
+```
 
 #### Custom Notifications
 

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -228,7 +228,7 @@ Configurable authentication settings have not yet been built, but can easily be 
 
 #### Slack Notifications
 
-Create a `screwdriver-bot` user in your Slack instance. Generate a Slack token for the new user and set it in your Slack notifications settings.
+Create a `screwdriver-bot` [Slack bot user](https://api.slack.com/bot-users) in your Slack instance. Generate a Slack token for the bot and set the `token` field with it in your Slack notifications settings.
 
 ```yaml
 # config/local.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,14 +12,14 @@ is_homepage: true
 </div>
 
 <div class="row">
+    <div class="col-xs-6 col-md-4 ug">
+        <h2>User Guide</h2>
+        <p>If you'd like to use Screwdriver to run a build, visit our <a href="http://docs.screwdriver.cd/user-guide/quickstart">User Guide</a>.</p>
+    </div>
     <div class="col-xs-6 col-md-4 cm">
         <h2>Cluster Management</h2>
         <p>To find more information about managing your own Screwdriver cluster,
         visit the <a href="http://docs.screwdriver.cd/cluster-management">Cluster Management</a> section.</p>
-    </div>
-    <div class="col-xs-6 col-md-4 ug">
-        <h2>User Guide</h2>
-        <p>If you'd like to use Screwdriver to run a build, visit our <a href="http://docs.screwdriver.cd/user-guide/quickstart">User Guide</a>.</p>
     </div>
     <div class="col-xs-6 col-md-4 about">
         <h2>About</h2>

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -13,7 +13,30 @@ toc:
 ---
 # Settings
 Configurable settings for any additional build plugins added to Screwdriver.cd.
-The settings can be set in `shared`, to apply to all jobs, or in an individual job. A job setting will completely override the `shared` setting.
+
+The settings can be set in `shared`, to apply to all jobs, or in an individual job. A job-level setting will completely override the `shared` setting.
+
+If you don't configure the build status, the notification will default to sending notifications on `FAILURE` only.
+
+```
+shared:
+    settings:
+        email: [test@email.com, test2@email.com]
+        slack: 'mychannel'
+
+jobs:
+    main:
+        template: example/mytemplate@stable
+```
+
+```
+jobs:
+    main:
+        template: example/mytemplate@stable
+        settings:
+            email: [test@email.com, test2@email.com]
+            slack: 'mychannel'
+```
 
 ## Email
 To enable emails to be sent as a result of build events, use the email setting.
@@ -21,11 +44,6 @@ You can configure a list of one or more email addresses to contact. You can also
 
 ### Example
 ```
-shared:
-    template: example/mytemplate@stable
-
-jobs:
-    main:
         settings:
             email:
                 addresses: [test@email.com, test2@email.com]
@@ -34,43 +52,13 @@ jobs:
 
 ## Slack
 To enable Slack notifications to be sent as a result of build events, invite the `screwdriver-bot` Slack bot to your channel(s) and use the Slack setting in your Screwdriver yaml.
-You can configure a list of one or more Slack channels to notify. You can also configure when to send a slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`. If you don't configure the build status, it'll default to sending notifications on `FAILURE` only.
+You can configure a list of one or more Slack channels to notify. You can also configure when to send a Slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`.
 
-### Examples
-
-This simple Slack setting will only send Slack notifications to `mychannel` on build failures:
-
-```
-shared:
-    template: example/mytemplate@stable
-
-jobs:
-    main:
-        settings:
-            slack: 'mychannel'
-```
-
-This Slack setting will send Slack notifications to `mychannel` and `my-other-channel` on build failures:
-
-```
-shared:
-    template: example/mytemplate@stable
-
-jobs:
-    main:
-        settings:
-            slack:
-                channels: ['mychannel', 'my-other-channel']
-```
+### Example
 
 This Slack setting will send Slack notifications to `mychannel` and `my-other-channel` on all build statuses:
 
 ```
-shared:
-    template: example/mytemplate@stable
-
-jobs:
-    main:
         settings:
             slack:
                 channels:
@@ -83,6 +71,7 @@ jobs:
                      - QUEUED
                      - RUNNING
 ```
-### Example success notification
+
+Success notification:
 
 ![Slack notification](../assets/slack-notification.png)

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -13,6 +13,7 @@ toc:
 ---
 # Settings
 Configurable settings for any additional build plugins added to Screwdriver.cd.
+The settings can be set in `shared`, to apply to all jobs, or in an individual job. A job setting will completely override the `shared` setting.
 
 ## Email
 To enable emails to be sent as a result of build events, use the email setting.
@@ -31,10 +32,8 @@ jobs:
                 statuses: [SUCCESS, FAILURE]
 ```
 
-The settings email configuration can be set in `shared`, to apply to all jobs, or in an individual job. A job `email` configuration will completely override the `shared` setting.
-
 ## Slack
-To enable Slack notifications to be sent as a result of build events, invite the Slack user `screwdriver-bot` to your channel(s) and use the Slack setting in your Screwdriver yaml.
+To enable Slack notifications to be sent as a result of build events, invite the `screwdriver-bot` Slack bot to your channel(s) and use the Slack setting in your Screwdriver yaml.
 You can configure a list of one or more Slack channels to notify. You can also configure when to send a slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`. If you don't configure the build status, it'll default to sending notifications on `FAILURE` only.
 
 ### Examples
@@ -87,5 +86,3 @@ jobs:
 ### Example success notification
 
 ![Slack notification](../assets/slack-notification.png)
-
-The settings slack configuration can be set in `shared`, to apply to all jobs, or in an individual job. A job `slack` configuration will completely override the `shared` setting.

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -8,6 +8,8 @@ toc:
       url: "#settings"
     - title: Email
       url: "#email"
+    - title: Slack
+      url: "#slack"
 ---
 # Settings
 Configurable settings for any additional build plugins added to Screwdriver.cd.
@@ -30,3 +32,60 @@ jobs:
 ```
 
 The settings email configuration can be set in `shared`, to apply to all jobs, or in an individual job. A job `email` configuration will completely override the `shared` setting.
+
+## Slack
+To enable Slack notifications to be sent as a result of build events, invite the Slack user `screwdriver-bot` to your channel(s) and use the Slack setting in your Screwdriver yaml.
+You can configure a list of one or more Slack channels to notify. You can also configure when to send a slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`. If you don't configure the build status, it'll default to sending notifications on `FAILURE` only.
+
+### Examples
+
+This simple Slack setting will only send Slack notifications to `mychannel` on build failures:
+
+```
+shared:
+    template: example/mytemplate@stable
+
+jobs:
+    main:
+        settings:
+            slack: 'mychannel'
+```
+
+This Slack setting will send Slack notifications to `mychannel` and `my-other-channel` on build failures:
+
+```
+shared:
+    template: example/mytemplate@stable
+
+jobs:
+    main:
+        settings:
+            slack:
+                channels: ['mychannel', 'my-other-channel']
+```
+
+This Slack setting will send Slack notifications to `mychannel` and `my-other-channel` on all build statuses:
+
+```
+shared:
+    template: example/mytemplate@stable
+
+jobs:
+    main:
+        settings:
+            slack:
+                channels:
+                     - 'mychannel'
+                     - 'my-other-channel'
+                statuses:
+                     - SUCCESS
+                     - FAILURE
+                     - ABORTED
+                     - QUEUED
+                     - RUNNING
+```
+### Example success notification
+
+![Slack notification](../assets/slack-notification.png)
+
+The settings slack configuration can be set in `shared`, to apply to all jobs, or in an individual job. A job `slack` configuration will completely override the `shared` setting.


### PR DESCRIPTION
## Context
Have added new Slack functionality.

## Objective
This PR:
- updates documentation with new Slack notifications feature.
- adds Slack notifications repo to contributing doc
- switches order of description section on the guide landing page

![screencapture-127-0-0-1-4000-user-guide-configuration-settings-1516735970895](https://user-images.githubusercontent.com/3230529/35296534-3dbce97e-0031-11e8-9f6a-f16b23389f3b.png)


<img width="842" alt="screen shot 2018-01-22 at 11 33 38 am" src="https://user-images.githubusercontent.com/3230529/35241184-7fdb12f8-ff6a-11e7-99f9-feae161db80a.png">


## Related links
- Slack notifications repo: https://github.com/screwdriver-cd/notifications-slack
- Original issue: https://github.com/screwdriver-cd/screwdriver/issues/687