### PR TITLE
feat(911): Add source paths

### DIFF
--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -24,6 +24,8 @@
           url: "/user-guide/configuration/annotations"
         - title: "Secrets"
           url: "/user-guide/configuration/secrets"
+        - title: "Source Paths"
+          url: "/user-guide/configuration/sourcePaths"
     - title: "Metadata"
       url: "/user-guide/metadata"
     - title: "Environment Variables"
@@ -58,8 +60,6 @@
       subcategories:
         - title: "Domain Model"
           url: "/about/appendix/domain"
-        - title: "Execution Engines"
-          url: "/about/appendix/execution-engines"
     - title: "Contributing"
       url: "/about/contributing"
     - title: "Support"

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -90,7 +90,7 @@
                     your search terms below.
                 </p>
                 <form role="form">
-                    <input type="search" class="form-control" id="search" placeholder="Search..." autocomplete="off">
+                    <input autofocus type="search" class="form-control" id="search" placeholder="Search..." autocomplete="off">
                 </form>
                 <div id="results" class="all-posts results"></div>
             </div>

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -77,7 +77,7 @@ The **[screwdriver][api-repo]** repo is the core of screwdriver, providing the A
 
 The **[launcher][launcher-repo]** performs step execution and housekeeping internal to build containers. This is written in Go and mounted into build containers as a binary.
 
-* **[sd-cmd][sd-cmd-repo]**: A Go-based CLI for sharing binaries which allows people a single interface for executing a versioned command (via remote binary, docker image, or habitat package) during a Screwdriver build
+* **[sd-cmd][sd-cmd-repo]**: A Go-based CLI for sharing binaries which provides a single interface for executing a versioned command (via remote binary, docker image, or habitat package) during a Screwdriver build
 * **[sd-step][sd-step-repo]**: A Shared Step allows people to use the same packages and commands in all build containers, regardless of build environment
 * **[meta-cli][meta-cli-repo]**: A Go-based CLI for reading/writing information from the metadata
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -77,6 +77,7 @@ The **[screwdriver][api-repo]** repo is the core of screwdriver, providing the A
 
 The **[launcher][launcher-repo]** performs step execution and housekeeping internal to build containers. This is written in Go and mounted into build containers as a binary.
 
+* **[sd-cmd][sd-cmd-repo]**: A Go-based CLI for sharing binaries which allows people a single interface for executing a versioned command (via remote binary, docker image, or habitat package) during a Screwdriver build
 * **[sd-step][sd-step-repo]**: A Shared Step allows people to use the same packages and commands in all build containers, regardless of build environment
 * **[meta-cli][meta-cli-repo]**: A Go-based CLI for reading/writing information from the metadata
 
@@ -203,6 +204,7 @@ The organization [screwdriver-cd-test][screwdriver-cd-test-org] contains various
 [scm-bitbucket-repo]: https://github.com/screwdriver-cd/scm-bitbucket
 [scm-github-repo]: https://github.com/screwdriver-cd/scm-github
 [screwdriver-cd-test-org]: https://github.com/screwdriver-cd-test
+[sd-cmd-repo]: https://github.com/screwdriver-cd/sd-cmd
 [sd-step-repo]: https://github.com/screwdriver-cd/sd-step
 [store-repo]: https://github.com/screwdriver-cd/store
 [template-main-repo]: https://github.com/screwdriver-cd/template-main

--- a/docs/user-guide/configuration/annotations.md
+++ b/docs/user-guide/configuration/annotations.md
@@ -10,7 +10,7 @@ toc:
 # Annotations
 Annotations is a freeform key/value store, often used to configure build execution settings. Annotations may be used as a sandbox for [YAML anchors and aliases](http://blog.daemonl.com/2016/02/yaml.html).
 
-### Example
+#### Example
 ```
 shared:
     template: example/mytemplate@stable
@@ -29,5 +29,5 @@ Some Annotations are used to modify the properties of the build environment. The
 | Annotation | Values | Description |
 |------------|--------|-------------|
 | beta.screwdriver.cd/executor | Ask your cluster admin | This will determine what compute system is used to run the build. For example, set the build to run in a VM, a kubernetes pod, a docker container, or a Jenkins agent. |
-| beta.screwdriver.cd/cpu | `LOW` / `HIGH` | When using a `k8s-vm` executor, this will allow the user to choose between 2 CPU resources (`LOW`) and 6 CPU resources (`HIGH`). Default is `LOW`. | 
+| beta.screwdriver.cd/cpu | `LOW` / `HIGH` | When using a `k8s-vm` executor, this will allow the user to choose between 2 CPU resources (`LOW`) and 6 CPU resources (`HIGH`). Default is `LOW`. |
 | beta.screwdriver.cd/ram | `LOW` / `HIGH` | When using a `k8s-vm` executor, this will allow the user to choose between 2 GB RAM (`LOW`) and 12 GB RAM (`HIGH`). Default is `LOW`. |

--- a/docs/user-guide/configuration/annotations.md
+++ b/docs/user-guide/configuration/annotations.md
@@ -19,6 +19,7 @@ shared:
             image: node:8
 
 jobs:
+    requires: [~pr, ~commit]
     main: *bar                  # Referencing the annotation anchor to use that config for main job
                                 # This will cause the main job to use a node:8 image
 ```

--- a/docs/user-guide/configuration/environment.md
+++ b/docs/user-guide/configuration/environment.md
@@ -10,7 +10,7 @@ toc:
 # Environment
 A set of key/value pairs for environment variables that need to available in a build. If an environment variable is set in both shared and a specific job, the value from the job configuration will be used.
 
-### Example
+#### Example
 ```
 shared:
     template: example/mytemplate@stable

--- a/docs/user-guide/configuration/environment.md
+++ b/docs/user-guide/configuration/environment.md
@@ -19,7 +19,9 @@ shared:
         MYVAR: hello        # This will set MYVAR=hello in all builds
 jobs:
     main:
+        requires: [~pr, ~commit]
         environment:
             FOO: baz        # This will set FOO=baz in the build
-    main2: {}               # This will set FOO=bar in the build
+    main2:                  # This will set FOO=bar in the build
+        requires: [main]
 ```

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -73,7 +73,7 @@ You can access information about properties by hovering over the property name.
         </div>
         <div id="sourcePaths" class="hidden">
             <h4>Source Paths</h4>
-            <p>You can optionally specify source paths that will trigger a job upon modification. In this example, the "main" job will only run if changes are made to things under the "src/app/" directory or the "screwdriver.yaml" file. Due to limitations in Git APIs, this feature is only available for Github SCM.</p>
+            <p>You can optionally specify source paths that will trigger a job upon modification. In this example, the "main" job will only run if changes are made to things under the "src/app/" directory or the "screwdriver.yaml" file. This feature is only available for Github SCM.</p>
         </div>
         <div id="shared" class="hidden">
             <h4>Shared</h4>

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -33,6 +33,7 @@ You can access information about properties by hovering over the property name.
 <a href="#jobs"><span class="key">jobs</span>:</a>
       <span class="key">main</span>:
         <a href="#requires"><span class="key">requires</span>: <span class="value">[~pr, ~commit, ~sd@123:main]</span></a>
+        <a href="#sourcePaths"><span class="key">sourcePaths</span>: <span class="value">["src/app/", "screwdriver.yaml"]</span></a>
         <a href="#image"><span class="key">image</span>: <span class="value">node:6</span></a>
         <a href="#steps"><span class="key">steps</span>:
     - <span class="key">init</span>: <span class="value">npm install</span>
@@ -69,6 +70,10 @@ You can access information about properties by hovering over the property name.
         <div id="requires" class="hidden">
             <h4>Requires</h4>
             <p>A single job name or array of jobs that will trigger the job to run. Jobs defined with "requires: ~pr" are started by pull-request events. Jobs defined with "requires: ~commit" are started by push events. Jobs defined with "requires: ~sd@123:main" are started by job "main" from pipeline "123". Jobs defined with "requires: [deploy-west, deploy-east] are started after "deploy-west" and "deploy-east" are both done running successfully. "Note: ~ jobs denote an OR functionality, jobs without a ~ denote join functionality.</p>
+        </div>
+        <div id="sourcePaths" class="hidden">
+            <h4>Source Paths</h4>
+            <p>You can optionally specify source paths that will trigger a job upon modification. In this example, the "main" job will only run if changes are made to things under the "src/app/" directory or the "screwdriver.yaml" file.</p>
         </div>
         <div id="shared" class="hidden">
             <h4>Shared</h4>

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -73,7 +73,7 @@ You can access information about properties by hovering over the property name.
         </div>
         <div id="sourcePaths" class="hidden">
             <h4>Source Paths</h4>
-            <p>You can optionally specify source paths that will trigger a job upon modification. In this example, the "main" job will only run if changes are made to things under the "src/app/" directory or the "screwdriver.yaml" file.</p>
+            <p>You can optionally specify source paths that will trigger a job upon modification. In this example, the "main" job will only run if changes are made to things under the "src/app/" directory or the "screwdriver.yaml" file. Due to limitations in Git APIs, this feature is only available for Github SCM.</p>
         </div>
         <div id="shared" class="hidden">
             <h4>Shared</h4>

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -13,7 +13,7 @@ toc:
     - title: Shared Configuration
       url: "#shared"
 ---
-# Job configuration
+# Job Configuration
 Jobs are how you define what happens in every build. Every job configuration must consist of an `image` and a list of `steps`, or a `template`. It also defines trigger requirement for the job using `requires`. See [workflow](/user-guide/configuration/workflow) for detailed usage of `requires` to create pipeline workflow.
 
 #### Example
@@ -24,7 +24,7 @@ jobs:
         steps:
             - init: npm install
             - test: npm test
-    main2: 
+    main2:
         template: example/mytemplate@stable
 ```
 

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -20,11 +20,13 @@ Jobs are how you define what happens in every build. Every job configuration mus
 ```
 jobs:
     main:
+        requires: [~pr, ~commit]
         image: node:6
         steps:
             - init: npm install
             - test: npm test
     main2:
+        requires: main
         template: example/mytemplate@stable
 ```
 
@@ -35,6 +37,7 @@ The `image` configuration refers to a docker image, e.g. an container from [hub.
 ```
 jobs:
     main:
+        requires: [~pr, ~commit]
         image: my-custom-registry.example.com/myorg/myimage:label
         steps:
             - step1: echo hello
@@ -48,6 +51,7 @@ Steps are the list of instructions you want to execute in your build. These shou
 ```
 jobs:
     main:
+        requires: [~pr, ~commit]
         image: node:8
         steps:
             - step_name: step_command --arg1 --arg2 foo
@@ -69,8 +73,10 @@ shared:
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         image: node:6
     main2:
+        requires: [main]
         steps:
             - greet: echo hello
 ```
@@ -79,11 +85,13 @@ The above example would be equivalent to:
 ```
 jobs:
     main:
+        requires: [~pr, ~commit]
         image: node:6
         steps:
             - init: npm install
             - test: npm test
     main2:
+        requires: [main]
         image: node:8
         steps:
             - greet: echo hello

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -26,12 +26,14 @@ shared:
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         template: example/mytemplate@stable
 ```
 
 ```
 jobs:
     main:
+        requires: [~pr, ~commit]
         template: example/mytemplate@stable
         settings:
             email: [test@email.com, test2@email.com]

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -42,7 +42,7 @@ jobs:
 To enable emails to be sent as a result of build events, use the email setting.
 You can configure a list of one or more email addresses to contact. You can also configure when to send an email, e.g. when the build status is `SUCCESS` and/or `FAILURE`.
 
-### Example
+#### Example
 ```
         settings:
             email:
@@ -54,7 +54,7 @@ You can configure a list of one or more email addresses to contact. You can also
 To enable Slack notifications to be sent as a result of build events, invite the `screwdriver-bot` Slack bot to your channel(s) and use the Slack setting in your Screwdriver yaml.
 You can configure a list of one or more Slack channels to notify. You can also configure when to send a Slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`.
 
-### Example
+#### Example
 
 This Slack setting will send Slack notifications to `mychannel` and `my-other-channel` on all build statuses:
 

--- a/docs/user-guide/configuration/sourcePaths.md
+++ b/docs/user-guide/configuration/sourcePaths.md
@@ -12,7 +12,7 @@ toc:
 Source paths can be used to specify source code paths that will trigger a job upon modification. This is done by using a `sourcePaths` keyword in your job definition as a string or array of strings. This can be useful for running workflows based on subdirectories in a [monorepo](https://developer.atlassian.com/blog/2015/10/monorepos-in-git).
 
 
-_Note: Due to limitations in Git APIs, this feature is only available for [Github SCM](https://github.com/screwdriver-cd/scm-github)._
+_Note: This feature is only available for [Github SCM](https://github.com/screwdriver-cd/scm-github)._
 
 ## Types of source paths
 You can either specify subdirectories and/or specific files as source paths. To denote a subdirectory, leave a trailing slash (`/`) at the end.

--- a/docs/user-guide/configuration/sourcePaths.md
+++ b/docs/user-guide/configuration/sourcePaths.md
@@ -11,6 +11,9 @@ toc:
 # Source Paths
 Source paths can be used to specify source code paths that will trigger a job upon modification. This is done by using a `sourcePaths` keyword in your job definition as a string or array of strings. This can be useful for running workflows based on subdirectories in a [monorepo](https://developer.atlassian.com/blog/2015/10/monorepos-in-git).
 
+
+_Note: Due to limitations in Git APIs, this feature is only available for [Github SCM](https://github.com/screwdriver-cd/scm-github)._
+
 ## Types of source paths
 You can either specify subdirectories and/or specific files as source paths. To denote a subdirectory, leave a trailing slash (`/`) at the end.
 

--- a/docs/user-guide/configuration/sourcePaths.md
+++ b/docs/user-guide/configuration/sourcePaths.md
@@ -1,0 +1,28 @@
+---
+layout: main
+title: Source Paths
+category: User Guide
+menu: menu
+toc:
+    - title: Source Paths
+      url: "#source-paths"
+
+---
+# Source Paths
+Source paths can be used to specify source code paths that will trigger a job upon modification. This is done by using a `sourcePaths` keyword in your job definition as a string or array of strings. This can be useful for running workflows based on subdirectories in a [monorepo](https://developer.atlassian.com/blog/2015/10/monorepos-in-git).
+
+## Types of source paths
+You can either specify subdirectories and/or specific files as source paths. To denote a subdirectory, leave a trailing slash (`/`) at the end.
+
+#### Example
+In the following example, the job `main` will start after any SCM pull-request, _or_ commit event on files under `src/app/` or the `screwdriver.yaml` file.
+
+```yaml
+jobs:
+      main:
+            image: node:6
+            requires: [~pr, ~commit]
+            sourcePaths: ["src/app/", "screwdriver.yaml"]
+            steps:
+                - echo: echo hi
+```


### PR DESCRIPTION
## Objective
This PR:
- adds source path docs
<img width="822" alt="screen shot 2018-03-31 at 12 43 54 am" src="https://user-images.githubusercontent.com/3230529/38161297-45ddc090-3481-11e8-8ee1-881e9bf9837c.png">
<img width="1174" alt="screen shot 2018-03-31 at 1 15 23 am" src="https://user-images.githubusercontent.com/3230529/38161298-484801b0-3481-11e8-9e45-b462fa52ba8a.png">

Also:
- autofocuses on the search form
- fixes some small formatting
- removes execution engines doc from the menu
- adds sd-cmd to the contributing doc

## Related links
https://github.com/screwdriver-cd/screwdriver/issues/911