### PR TITLE
fix: path for two pics in domain model page

### DIFF
--- a/docs/about/appendix/domain.md
+++ b/docs/about/appendix/domain.md
@@ -3,7 +3,7 @@ layout: main
 title: Domain Model
 category: About
 menu: menu
-toc: 
+toc:
     - title: Domain Model
       url: "#domain-model"
       active: true
@@ -30,8 +30,8 @@ toc:
 
 _Note: `Parallel`, `series`, and `matrix` have not been implemented yet. Everything will run in series by default._
 
-![Definition](./assets/definition-model.png)
-![Runtime](./assets/runtime-model.png)
+![Definition](../appendix/assets/definition-model.png)
+![Runtime](../appendix/assets/runtime-model.png)
 
 ### Source Code
 


### PR DESCRIPTION
To stop showing icons like:
![screen shot 2018-04-09 at 3 27 33 pm](https://user-images.githubusercontent.com/1882121/38526316-97f53af8-3c0a-11e8-8012-1713366afb0a.png)

But showing the intended graphs:
![screen shot 2018-04-09 at 3 28 26 pm](https://user-images.githubusercontent.com/1882121/38526330-ab85ab5c-3c0a-11e8-804f-ca14074577b3.png)
