### PR TITLE
Clarify path to sd-cmd file

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -70,7 +70,7 @@ description: |
 maintainer: foo@bar.com # Maintainer of the command
 format: binary # Format the command is in (binary)
 binary:
-    file: ./foobar.sh # Path to script or binary file
+    file: ./foobar.sh # Path to script or binary file from repository root
 ```
 
 ### Writing a screwdriver.yaml for your command repo


### PR DESCRIPTION
The file path is relative to the repository root and not from where the `sd-command.yaml` file is located.

Also `sd-cmd publish` fails miserably in this case where it can't find the script/file (pasted below), so I'd suggest returning a more appropriate message when this happens.

```
13:51:38
 ERROR: Something terrible has happened. Please file a ticket with this info:
13:51:38
 ERROR: runtime error: invalid memory address or nil pointer dereference
13:51:38
 goroutine 1 [running]:
13:51:38
 runtime/debug.Stack(0x72d0c0, 0xc42000e020, 0xc420061858)
13:51:38
 /usr/local/go/src/runtime/debug/stack.go:24 +0xa7
13:51:38
 main.finalRecover()
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/sd-cmd.go:40 +0xcb
13:51:38
 panic(0x6a1e80, 0x876700)
13:51:38
 /usr/local/go/src/runtime/panic.go:505 +0x229
13:51:38
 bytes.(*Buffer).Len(...)
13:51:38
 /usr/local/go/src/bytes/buffer.go:74
13:51:38
 net/http.NewRequest(0x6f5118, 0x4, 0xc4200204c0, 0x37, 0x72cac0, 0x0, 0xc, 0xc420018fe0, 0x0)
13:51:38
 /usr/local/go/src/net/http/request.go:802 +0x541
13:51:38
 github.com/screwdriver-cd/sd-cmd/screwdriver/api.client.sendHTTPRequest(0xc42002014b, 0x2f, 0xc42001e009, 0x296, 0xc42006f410, 0x6f5118, 0x4, 0xc4200204c0, 0x37, 0x0, ...)
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/screwdriver/api/api.go:227 +0xab
13:51:38
 github.com/screwdriver-cd/sd-cmd/screwdriver/api.client.httpRequest(0xc42002014b, 0x2f, 0xc42001e009, 0x296, 0xc42006f410, 0x6f5118, 0x4, 0xc4200204c0, 0x37, 0x0, ...)
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/screwdriver/api/api.go:157 +0xbb
13:51:38
 github.com/screwdriver-cd/sd-cmd/screwdriver/api.client.PostCommand(0xc42002014b, 0x2f, 0xc42001e009, 0x296, 0xc42006f410, 0x7ffd29a9d66c, 0x1b, 0xc42010c000, 0xc42006f401, 0xc42006f440, ...)
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/screwdriver/api/api.go:218 +0x295
13:51:38
 github.com/screwdriver-cd/sd-cmd/publisher.(*Publisher).Run(0xc42006f440, 0xc42006f3e0, 0xc4200100e0)
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/publisher/publisher.go:22 +0x52
13:51:38
 main.runPublisher(0xc4200100e0, 0x2, 0x2, 0x30, 0x6c9ce0)
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/sd-cmd.go:68 +0x1c1
13:51:38
 main.runCommand(0x72e420, 0xc42006f380, 0xc4200100c0, 0x4, 0x4, 0x14, 0xc420014045)
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/sd-cmd.go:80 +0x132
13:51:38
 main.main()
13:51:38
 /sd/workspace/src/github.com/screwdriver-cd/sd-cmd/sd-cmd.go:93 +0x141
```