### PR TITLE
docs(Japanese): translate sourcePaths.md

### DIFF
--- a/docs/_data/menu_ja.yml
+++ b/docs/_data/menu_ja.yml
@@ -24,7 +24,7 @@
           url: "/user-guide/configuration/annotations"
         - title: "Secrets"
           url: "/ja/user-guide/configuration/secrets"
-        - title: "Source Paths"
+        - title: "ソースパス"
           url: "/ja/user-guide/configuration/sourcePaths"
     - title: "Metadata"
       url: "/ja/user-guide/metadata"

--- a/docs/_data/menu_ja.yml
+++ b/docs/_data/menu_ja.yml
@@ -25,7 +25,7 @@
         - title: "Secrets"
           url: "/ja/user-guide/configuration/secrets"
         - title: "Source Paths"
-          url: "/user-guide/configuration/sourcePaths"
+          url: "/ja/user-guide/configuration/sourcePaths"
     - title: "Metadata"
       url: "/ja/user-guide/metadata"
     - title: "環境変数"

--- a/docs/ja/user-guide/configuration/sourcePaths.md
+++ b/docs/ja/user-guide/configuration/sourcePaths.md
@@ -1,0 +1,60 @@
+---
+layout: main
+title: ソースパス
+category: User Guide
+menu: menu_ja
+toc:
+- title: ソースパス
+  url: "#ソースパス"
+---
+
+# ソースパス
+
+ソースパス機能を使うことで、特定のソースコードが更新された場合にのみジョブをトリガーすることができます。ジョブ定義の中で `sourcePaths` を文字列または文字列の配列で設定することで利用できます。この機能は [monorepo](https://developer.atlassian.com/blog/2015/10/monorepos-in-git) のサブディレクトリに基づいたワークフローを実現するのに役立ちます。
+
+## ソースパスの種類
+
+特定のサブディレクトリと特定のファイルの両方をソースパスとして設定できます。サブディレクトリであることを示すには、 最後にスラッシュ (`/`) を付けます。設定するパスはリポジトリルートからの相対パスです。
+
+#### 例
+
+以下のような構造のリポジトリを例とします:
+
+```
+┌── README.md
+├── screwdriver.yaml
+├── test/
+│   └── ...
+├── src/
+│   ├── app/
+│   │   ├── main.js
+│   │   ├── ...
+│   │   └── package.json
+│   └── other/
+│       └── ...
+│
+...
+```
+
+また、このような `screwdriver.yaml` があるとします:
+
+```yaml
+jobs:
+    main:
+        image: node:6
+        requires: [~pr, ~commit]
+        sourcePaths: ["src/app/", "screwdriver.yaml"]
+        steps:
+            - echo: echo hi
+```
+
+この例では、`main` ジョブは `src/app/` 以下にあるファイル (`src/app/main.js`, 
+ `src/app/package.json` など) の更新、または 
+ `screwdriver.yaml` の更新でトリガーされます。
+しかし `main` ジョブは、`README.md`, `test/` または `src/other/` の更新では**トリガーされません**
+
+### 警告
+
+- この機能は現在 [Github SCM](https://github.com/screwdriver-cd/scm-github) のみでご利用いただけます。
+- `sourcePaths` の設定は手動でパイプラインを実行したり、ジョブをリスタートした際は無視されます。
+- `screwdriver.yaml` はリポジトリルートに配置されている必要があります。

--- a/docs/ja/user-guide/configuration/sourcePaths.md
+++ b/docs/ja/user-guide/configuration/sourcePaths.md
@@ -10,7 +10,7 @@ toc:
 
 # ソースパス
 
-ソースパス機能を使うことで、特定のソースコードが更新された場合にのみジョブをトリガーすることができます。ジョブ定義の中で `sourcePaths` を文字列または文字列の配列で設定することで利用できます。この機能は [monorepo](https://developer.atlassian.com/blog/2015/10/monorepos-in-git) のサブディレクトリに基づいたワークフローを実現するのに役立ちます。
+ソースパス機能を使うことで、特定のソースコードが更新された場合にのみジョブをトリガーすることができます。ジョブ定義の中で `sourcePaths` を文字列、または文字列の配列で設定することで利用できます。この機能は [monorepo](https://developer.atlassian.com/blog/2015/10/monorepos-in-git) のサブディレクトリに基づいたワークフローを実現するのに役立ちます。
 
 ## ソースパスの種類
 
@@ -48,10 +48,8 @@ jobs:
             - echo: echo hi
 ```
 
-この例では、`main` ジョブは `src/app/` 以下にあるファイル (`src/app/main.js`, 
- `src/app/package.json` など) の更新、または 
- `screwdriver.yaml` の更新でトリガーされます。
-しかし `main` ジョブは、`README.md`, `test/` または `src/other/` の更新では**トリガーされません**
+この例では、`main` ジョブは `src/app/` 以下にあるファイル (`src/app/main.js`, `src/app/package.json` など) の更新、または `screwdriver.yaml` の更新でトリガーされます。
+しかし `main` ジョブは、`README.md`, `test/` または `src/other/` の更新では**トリガーされません**。
 
 ### 警告
 


### PR DESCRIPTION
This PR translates `sourcePaths.md` into Japanese.

This is based on https://github.com/screwdriver-cd/guide/blob/master/docs/user-guide/configuration/sourcePaths.md .

[Check out a review request at GitLocalize](https://gitlocalize.com/repo/160/ja/review/762)