### PR TITLE
docs(cmd-fix): Fix mistake on version formatting for sd-commands

### DIFF
--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -64,7 +64,7 @@ Example `sd-command.yaml`:
 ```yaml
 namespace: foo # Namespace for the command
 name: bar # Command name
-version: 1.0 # Major and Minor version number (patch is automatic)
+version: '1.0' # Major and Minor version number (patch is automatic), must be a string
 description: |
   Lorem ipsum dolor sit amet.
 maintainer: foo@bar.com # Maintainer of the command


### PR DESCRIPTION
## Context

The version in `command.yaml` for publishing screwdriver commands needs to be a string according to the validator, but the guide's example uses a number.

## Objective

* Change version from number (`1.0`) to string (`'1.0'`)

## References

* https://github.com/screwdriver-cd/command-validator