### PR TITLE
docs(Japanese): translate configuration/index.md

### DIFF
--- a/docs/ja/user-guide/configuration/index.md
+++ b/docs/ja/user-guide/configuration/index.md
@@ -16,6 +16,8 @@ toc:
 各プロパティ名にマウスカーソルを乗せるとそれらの説明が表示されます。
 
 <div class="yaml-docs">
+</div>
+
 <pre class="example">
 <a href="#shared"><span class="key">shared</span>:</a>
     <a href="#environment"><span class="key">environment</span>:
@@ -32,6 +34,7 @@ toc:
 <a href="#jobs"><span class="key">jobs</span>:</a>
       <span class="key">main</span>:
         <a href="#requires"><span class="key">requires</span>: <span class="value">[~pr, ~commit, ~sd@123:main]</span></a>
+        <a href="#sourcePaths"><span class="key">sourcePaths</span>: <span class="value">["src/app/", "screwdriver.yaml"]</span></a>
         <a href="#image"><span class="key">image</span>: <span class="value">node:6</span></a>
         <a href="#steps"><span class="key">steps</span>:
     - <span class="key">init</span>: <span class="value">npm install</span>
@@ -64,6 +67,8 @@ toc:
         - <span class="key">echo</span>: <span class="value">echo done</span></a>
     <a href="#jobs">...</a>
 </pre>
+
+```
 <div class="yaml-side">
     <div id="requires" class="hidden">
         <h4>Requires</h4>
@@ -75,7 +80,7 @@ toc:
     </div>
     <div id="environment" class="hidden">
         <h4>Environment</h4>
-        <p>ビルドに必要な環境変数のキーと値の組み合わせです。ジョブに設定できる全ての設定はSharedにも設定できますが、個別のジョブの設定により上書きされます。</p>
+        <p>ビルドに必要な環境変数のキーと値の組み合わせです。ジョブに設定できる全ての設定はSharedにも設定できますが、ジョブの設定により上書きされます。</p>
     </div>
     <div id="settings" class="hidden">
         <h4>Settings</h4>
@@ -83,7 +88,7 @@ toc:
     </div>
     <div id="annotations" class="hidden">
         <h4>Annotations</h4>
-        <p>アノテーションはキーと値の組み合わせです。パイプラインまたはジョブ単位で設定することができます。アノテーションのキーと値は任意に設定することができ、例えば、ビルドの実行方法を変更することができます。Screwdriverのクラスタ管理者にビルドの実行方法を変更するために、どのようなアノテーションがサポートされているか確認してください。</p>
+        <p>アノテーションはキーバリューのペアです。パイプラインまたはジョブ単位で設定することができます。アノテーションのキーバリューは任意に設定することができ、例えば、ビルドの実行方法を変更することができます。Screwdriverのクラスタ管理者にビルドの実行方法を変更するために、どのようなアノテーションがサポートされているか確認してください。</p>
     </div>
     <div id="executor" class="hidden">
         <h4>Executor annotation</h4>
@@ -96,7 +101,6 @@ toc:
     <div id="ram" class="hidden">
         <h4>RAM annotation</h4>
         <p>`k8s-vm` Executor を利用する場合にVMに割り当てられるRAMを設定します。`LOW`はデフォルトで設定され、2GBのメモリが割り当てられ、`HIGH`は12GBのメモリが割り当てられます。</p>
-    </div>
     <div id="email" class="hidden">
         <h4>Email</h4>
         <p>通知を送信するEmailアドレスと、通知を送信するステータスを設定します。</p>
@@ -105,13 +109,24 @@ toc:
         <h4>Jobs</h4>
         <p>ビルドの挙動を定義するジョブのリストです。</p>
     </div>
+    <div id="main-job" class="hidden">
+        <h4>Main</h4>
+        <p>唯一の必須ジョブです。このジョブはコードに変更が行われた際に自動的に実行されます。</p>
+    </div>
     <div id="image" class="hidden">
         <h4>Image</h4>
-        <p>ビルドで利用されるDockerイメージを指定します。ここでの設定は"docker pull"コマンドを利用する場合と同じものです。</p>
+        <p>ビルドで利用されるDockerイメージを指定します。この例ではテンプレートを使用しており、{{NODE_VERSION}}のように波括弧で囲まれた変数が展開されます。 この変数はmatrixで指定されている値に変更され、それら複数のイメージを利用したビルドが並列に実行されます。</p>
+    </div>
+    <div id="matrix" class="hidden">
+        <h4>Matrix</h4>
+        <p>image設定にテンプレートが利用されている場合、そのジョブのビルドが複数のイメージを利用して並列に実行されます。</p>
     </div>
     <div id="steps" class="hidden">
         <h4>Steps</h4>
         <p>コマンドラインで入力するように、ビルドで実行されるコマンドのリストを定義します。同じジョブ内では、環境変数はステップ間で受け渡されます。ステップの定義は全てのジョブに必須です。Screwdriverのステップとして予約語になっているため、ステップ名を'sd-'で始めることはできません。Screwdriverは'/bin/sh'をステップ実行のために使用するため、異なるターミナルやシェルを使用すると予期せぬ振る舞いをするかもしれません。</p>
     </div>
-  </div>
 </div>
+```
+
+
+

--- a/docs/ja/user-guide/configuration/index.md
+++ b/docs/ja/user-guide/configuration/index.md
@@ -71,6 +71,10 @@ toc:
             <h4>Requires</h4>
             <p>ジョブ実行のトリガーとなる1つまたは複数のジョブの配列を設定します。"requires: ~pr"が設定されたジョブはプルリクエストイベントにより実行されます。"requires: ~commit"が設定されたジョブはプッシュイベントにより実行されます。"requires: ~sd@123:main"が設定されたジョブはパイプライン"123"の"main"ジョブの完了により実行されます。"requires: [deploy-west, deploy-east]"が設定されたジョブは"deploy-west"と"deploy-east"の両方のジョブの成功後に実行されます。"注意: ~ のジョブはOR条件で、~ なしのジョブはジョインの働きをします。"</p>
         </div>
+        <div id="sourcePaths" class="hidden">
+            <h4>Source Paths</h4>
+            <p>オプションで、変更時にジョブを起動するソースパスを指定できます。この例では、 "main"ジョブは "src/app/"ディレクトリ以下または "screwdriver.yaml"ファイルに変更が加えられた場合にのみ実行されます。この機能はGithub SCMでのみ使用できます。</p>
+        </div>
         <div id="shared" class="hidden">
             <h4>Shared</h4>
             <p>全てのジョブの適用されるグローバル設定を定義します。Sharedの設定は各ジョブにマージされますが、それぞれのジョブで更に設定が行われている場合はその設定により上書きされます。</p>
@@ -110,10 +114,6 @@ toc:
         <div id="image" class="hidden">
             <h4>Image</h4>
             <p>ビルドで利用されるDockerイメージを指定します。ここでの設定は"docker pull"コマンドを利用する場合と同じものです。</p>
-        </div>
-        <div id="matrix" class="hidden">
-            <h4>Matrix</h4>
-            <p>image設定にテンプレートが利用されている場合、そのジョブのビルドが複数のイメージを利用して並列に実行されます。</p>
         </div>
         <div id="steps" class="hidden">
             <h4>Steps</h4>

--- a/docs/ja/user-guide/configuration/index.md
+++ b/docs/ja/user-guide/configuration/index.md
@@ -73,7 +73,7 @@ toc:
         </div>
         <div id="sourcePaths" class="hidden">
             <h4>Source Paths</h4>
-            <p>オプションで、変更時にジョブを起動するソースパスを指定できます。この例では、 "main"ジョブは "src/app/"ディレクトリ以下または "screwdriver.yaml"ファイルに変更が加えられた場合にのみ実行されます。この機能はGithub SCMでのみ使用できます。</p>
+            <p>オプションとして、ジョブ実行のトリガーとなるソースパスを指定することができます。この例では、"main"ジョブは"src/app/"ディレクトリ以下または"screwdriver.yaml"ファイルに変更が加えられた場合にのみ実行されます。この機能はGithub SCMでのみ使用できます。</p>
         </div>
         <div id="shared" class="hidden">
             <h4>Shared</h4>

--- a/docs/ja/user-guide/configuration/index.md
+++ b/docs/ja/user-guide/configuration/index.md
@@ -16,7 +16,6 @@ toc:
 各プロパティ名にマウスカーソルを乗せるとそれらの説明が表示されます。
 
 <div class="yaml-docs">
-</div>
 
 <pre class="example">
 <a href="#shared"><span class="key">shared</span>:</a>
@@ -67,66 +66,62 @@ toc:
         - <span class="key">echo</span>: <span class="value">echo done</span></a>
     <a href="#jobs">...</a>
 </pre>
-
-```
-<div class="yaml-side">
-    <div id="requires" class="hidden">
-        <h4>Requires</h4>
-        <p>ジョブ実行のトリガーとなる1つまたは複数のジョブの配列を設定します。"requires: ~pr"が設定されたジョブはプルリクエストイベントにより実行されます。"requires: ~commit"が設定されたジョブはプッシュイベントにより実行されます。"requires: ~sd@123:main"が設定されたジョブはパイプライン"123"の"main"ジョブの完了により実行されます。"requires: [deploy-west, deploy-east]"が設定されたジョブは"deploy-west"と"deploy-east"の両方のジョブの成功後に実行されます。"注意: ~ のジョブはOR条件で、~ なしのジョブはジョインの働きをします。"</p>
-    </div>
-    <div id="shared" class="hidden">
-        <h4>Shared</h4>
-        <p>全てのジョブの適用されるグローバル設定を定義します。Sharedの設定は各ジョブにマージされますが、それぞれのジョブで更に設定が行われている場合はその設定により上書きされます。</p>
-    </div>
-    <div id="environment" class="hidden">
-        <h4>Environment</h4>
-        <p>ビルドに必要な環境変数のキーと値の組み合わせです。ジョブに設定できる全ての設定はSharedにも設定できますが、ジョブの設定により上書きされます。</p>
-    </div>
-    <div id="settings" class="hidden">
-        <h4>Settings</h4>
-        <p>Screwdriver.cdに追加されたビルドプラグインの設定です。</p>
-    </div>
-    <div id="annotations" class="hidden">
-        <h4>Annotations</h4>
-        <p>アノテーションはキーバリューのペアです。パイプラインまたはジョブ単位で設定することができます。アノテーションのキーバリューは任意に設定することができ、例えば、ビルドの実行方法を変更することができます。Screwdriverのクラスタ管理者にビルドの実行方法を変更するために、どのようなアノテーションがサポートされているか確認してください。</p>
-    </div>
-    <div id="executor" class="hidden">
-        <h4>Executor annotation</h4>
-        <p>デフォルト以外のExecutorでのビルドを実行したい場合に設定します。`jenkins`, `k8s-vm`が設定可能です。</p>
-    </div>
-    <div id="cpu" class="hidden">
-        <h4>CPU annotation</h4>
-        <p>`k8s-vm` Executor を利用する場合にVMに割り当てられるCPUを設定します。`LOW`はデフォルトで設定され、2CPUが割り当てられ、`HIGH`は6CPU割り当てられます。</p>
-    </div>
-    <div id="ram" class="hidden">
-        <h4>RAM annotation</h4>
-        <p>`k8s-vm` Executor を利用する場合にVMに割り当てられるRAMを設定します。`LOW`はデフォルトで設定され、2GBのメモリが割り当てられ、`HIGH`は12GBのメモリが割り当てられます。</p>
-    <div id="email" class="hidden">
-        <h4>Email</h4>
-        <p>通知を送信するEmailアドレスと、通知を送信するステータスを設定します。</p>
-    </div>
-    <div id="jobs" class="hidden">
-        <h4>Jobs</h4>
-        <p>ビルドの挙動を定義するジョブのリストです。</p>
-    </div>
-    <div id="main-job" class="hidden">
-        <h4>Main</h4>
-        <p>唯一の必須ジョブです。このジョブはコードに変更が行われた際に自動的に実行されます。</p>
-    </div>
-    <div id="image" class="hidden">
-        <h4>Image</h4>
-        <p>ビルドで利用されるDockerイメージを指定します。この例ではテンプレートを使用しており、{{NODE_VERSION}}のように波括弧で囲まれた変数が展開されます。 この変数はmatrixで指定されている値に変更され、それら複数のイメージを利用したビルドが並列に実行されます。</p>
-    </div>
-    <div id="matrix" class="hidden">
-        <h4>Matrix</h4>
-        <p>image設定にテンプレートが利用されている場合、そのジョブのビルドが複数のイメージを利用して並列に実行されます。</p>
-    </div>
-    <div id="steps" class="hidden">
-        <h4>Steps</h4>
-        <p>コマンドラインで入力するように、ビルドで実行されるコマンドのリストを定義します。同じジョブ内では、環境変数はステップ間で受け渡されます。ステップの定義は全てのジョブに必須です。Screwdriverのステップとして予約語になっているため、ステップ名を'sd-'で始めることはできません。Screwdriverは'/bin/sh'をステップ実行のために使用するため、異なるターミナルやシェルを使用すると予期せぬ振る舞いをするかもしれません。</p>
+    <div class="yaml-side">
+        <div id="requires" class="hidden">
+            <h4>Requires</h4>
+            <p>ジョブ実行のトリガーとなる1つまたは複数のジョブの配列を設定します。"requires: ~pr"が設定されたジョブはプルリクエストイベントにより実行されます。"requires: ~commit"が設定されたジョブはプッシュイベントにより実行されます。"requires: ~sd@123:main"が設定されたジョブはパイプライン"123"の"main"ジョブの完了により実行されます。"requires: [deploy-west, deploy-east]"が設定されたジョブは"deploy-west"と"deploy-east"の両方のジョブの成功後に実行されます。"注意: ~ のジョブはOR条件で、~ なしのジョブはジョインの働きをします。"</p>
+        </div>
+        <div id="shared" class="hidden">
+            <h4>Shared</h4>
+            <p>全てのジョブの適用されるグローバル設定を定義します。Sharedの設定は各ジョブにマージされますが、それぞれのジョブで更に設定が行われている場合はその設定により上書きされます。</p>
+        </div>
+        <div id="environment" class="hidden">
+            <h4>Environment</h4>
+            <p>ビルドに必要な環境変数のキーと値の組み合わせです。ジョブに設定できる全ての設定はSharedにも設定できますが、ジョブの設定により上書きされます。</p>
+        </div>
+        <div id="settings" class="hidden">
+            <h4>Settings</h4>
+            <p>Screwdriver.cdに追加されたビルドプラグインの設定です。</p>
+        </div>
+        <div id="annotations" class="hidden">
+            <h4>Annotations</h4>
+            <p>アノテーションはキーバリューのペアです。パイプラインまたはジョブ単位で設定することができます。アノテーションのキーバリューは任意に設定することができ、例えば、ビルドの実行方法を変更することができます。Screwdriverのクラスタ管理者にビルドの実行方法を変更するために、どのようなアノテーションがサポートされているか確認してください。</p>
+        </div>
+        <div id="executor" class="hidden">
+            <h4>Executor annotation</h4>
+            <p>デフォルト以外のExecutorでのビルドを実行したい場合に設定します。`jenkins`, `k8s-vm`が設定可能です。</p>
+        </div>
+        <div id="cpu" class="hidden">
+            <h4>CPU annotation</h4>
+            <p>`k8s-vm` Executor を利用する場合にVMに割り当てられるCPUを設定します。`LOW`はデフォルトで設定され、2CPUが割り当てられ、`HIGH`は6CPU割り当てられます。</p>
+        </div>
+        <div id="ram" class="hidden">
+            <h4>RAM annotation</h4>
+            <p>`k8s-vm` Executor を利用する場合にVMに割り当てられるRAMを設定します。`LOW`はデフォルトで設定され、2GBのメモリが割り当てられ、`HIGH`は12GBのメモリが割り当てられます。</p>
+        <div id="email" class="hidden">
+            <h4>Email</h4>
+            <p>通知を送信するEmailアドレスと、通知を送信するステータスを設定します。</p>
+        </div>
+        <div id="jobs" class="hidden">
+            <h4>Jobs</h4>
+            <p>ビルドの挙動を定義するジョブのリストです。</p>
+        </div>
+        <div id="main-job" class="hidden">
+            <h4>Main</h4>
+            <p>唯一の必須ジョブです。このジョブはコードに変更が行われた際に自動的に実行されます。</p>
+        </div>
+        <div id="image" class="hidden">
+            <h4>Image</h4>
+            <p>ビルドで利用されるDockerイメージを指定します。この例ではテンプレートを使用しており、{{NODE_VERSION}}のように波括弧で囲まれた変数が展開されます。 この変数はmatrixで指定されている値に変更され、それら複数のイメージを利用したビルドが並列に実行されます。</p>
+        </div>
+        <div id="matrix" class="hidden">
+            <h4>Matrix</h4>
+            <p>image設定にテンプレートが利用されている場合、そのジョブのビルドが複数のイメージを利用して並列に実行されます。</p>
+        </div>
+        <div id="steps" class="hidden">
+            <h4>Steps</h4>
+            <p>コマンドラインで入力するように、ビルドで実行されるコマンドのリストを定義します。同じジョブ内では、環境変数はステップ間で受け渡されます。ステップの定義は全てのジョブに必須です。Screwdriverのステップとして予約語になっているため、ステップ名を'sd-'で始めることはできません。Screwdriverは'/bin/sh'をステップ実行のために使用するため、異なるターミナルやシェルを使用すると予期せぬ振る舞いをするかもしれません。</p>
+        </div>
     </div>
 </div>
-```
-
-
 

--- a/docs/ja/user-guide/configuration/index.md
+++ b/docs/ja/user-guide/configuration/index.md
@@ -77,7 +77,7 @@ toc:
         </div>
         <div id="environment" class="hidden">
             <h4>Environment</h4>
-            <p>ビルドに必要な環境変数のキーと値の組み合わせです。ジョブに設定できる全ての設定はSharedにも設定できますが、ジョブの設定により上書きされます。</p>
+            <p>ビルドに必要な環境変数のキーと値の組み合わせです。ジョブに設定できる全ての設定はSharedにも設定できますが、個別のジョブの設定により上書きされます。</p>
         </div>
         <div id="settings" class="hidden">
             <h4>Settings</h4>
@@ -85,7 +85,7 @@ toc:
         </div>
         <div id="annotations" class="hidden">
             <h4>Annotations</h4>
-            <p>アノテーションはキーバリューのペアです。パイプラインまたはジョブ単位で設定することができます。アノテーションのキーバリューは任意に設定することができ、例えば、ビルドの実行方法を変更することができます。Screwdriverのクラスタ管理者にビルドの実行方法を変更するために、どのようなアノテーションがサポートされているか確認してください。</p>
+            <p>アノテーションはキーと値の組み合わせです。パイプラインまたはジョブ単位で設定することができます。アノテーションのキーと値は任意に設定することができ、例えば、ビルドの実行方法を変更することができます。Screwdriverのクラスタ管理者にビルドの実行方法を変更するために、どのようなアノテーションがサポートされているか確認してください。</p>
         </div>
         <div id="executor" class="hidden">
             <h4>Executor annotation</h4>
@@ -98,6 +98,7 @@ toc:
         <div id="ram" class="hidden">
             <h4>RAM annotation</h4>
             <p>`k8s-vm` Executor を利用する場合にVMに割り当てられるRAMを設定します。`LOW`はデフォルトで設定され、2GBのメモリが割り当てられ、`HIGH`は12GBのメモリが割り当てられます。</p>
+        </div>
         <div id="email" class="hidden">
             <h4>Email</h4>
             <p>通知を送信するEmailアドレスと、通知を送信するステータスを設定します。</p>
@@ -106,13 +107,9 @@ toc:
             <h4>Jobs</h4>
             <p>ビルドの挙動を定義するジョブのリストです。</p>
         </div>
-        <div id="main-job" class="hidden">
-            <h4>Main</h4>
-            <p>唯一の必須ジョブです。このジョブはコードに変更が行われた際に自動的に実行されます。</p>
-        </div>
         <div id="image" class="hidden">
             <h4>Image</h4>
-            <p>ビルドで利用されるDockerイメージを指定します。この例ではテンプレートを使用しており、{{NODE_VERSION}}のように波括弧で囲まれた変数が展開されます。 この変数はmatrixで指定されている値に変更され、それら複数のイメージを利用したビルドが並列に実行されます。</p>
+            <p>ビルドで利用されるDockerイメージを指定します。ここでの設定は"docker pull"コマンドを利用する場合と同じものです。</p>
         </div>
         <div id="matrix" class="hidden">
             <h4>Matrix</h4>


### PR DESCRIPTION
This PR translates configuration/index.md into Japanese again.
This is based on https://github.com/screwdriver-cd/guide/blob/master/docs/user-guide/configuration/index.md .

[Check out a review request at GitLocalize](https://gitlocalize.com/repo/160/ja/review/1072)