### PR TITLE
fix: Add SD_JOB_ID env var

### DIFF
--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -30,15 +30,16 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 
 | Name | Value |
 |------|-------|
-| SD_PIPELINE_ID | The ID of the pipeline |
-| SD_EVENT_ID | The ID of the event |
-| SD_PIPELINE_NAME | The name of the pipeline (e.g.: d2lam/myPipeline) |
-| SD_JOB_NAME | Job name (e.g.: main) |
 | SD_BUILD_ID | Build number (e.g.: 1, 2, etc) |
+| SD_EVENT_ID | The ID of the event |
+| SD_JOB_ID | The ID of the pipeline |
+| SD_JOB_NAME | Job name (e.g.: main) |
+| SD_PIPELINE_ID | The ID of the pipeline |
+| SD_PIPELINE_NAME | The name of the pipeline (e.g.: d2lam/myPipeline) |
 | SD_PULL_REQUEST | Pull Request number (blank if non-PR) |
-| SD_TOKEN | JWT token for the build |
 | SD_TEMPLATE_NAME | Name of the template the job is using (blank if not using template) |
 | SD_TEMPLATE_VERSION | Version of the template the job is using (blank if not using template)|
+| SD_TOKEN | JWT token for the build |
 
 ## Directories
 
@@ -78,6 +79,6 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 
 | Name | Value |
 |------|-------|
-| SCREWDRIVER | `true` |
 | CI | `true` |
 | CONTINUOUS_INTEGRATION | `true` |
+| SCREWDRIVER | `true` |


### PR DESCRIPTION
Missing documentation for SD_JOB_ID env var; also sorting alphabetically