### PR TITLE
feat(926): Adding template env vars and namespace to docs

### DIFF
--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -32,12 +32,14 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 |------|-------|
 | SD_BUILD_ID | Build number (e.g.: 1, 2, etc) |
 | SD_EVENT_ID | The ID of the event |
-| SD_JOB_ID | The ID of the pipeline |
+| SD_JOB_ID | The ID of the job |
 | SD_JOB_NAME | Job name (e.g.: main) |
 | SD_PIPELINE_ID | The ID of the pipeline |
 | SD_PIPELINE_NAME | The name of the pipeline (e.g.: d2lam/myPipeline) |
-| SD_PULL_REQUEST | Pull Request number (blank if non-PR) |
-| SD_TEMPLATE_NAME | Name of the template the job is using (blank if not using template) |
+| SD_PULL_REQUEST | Pull Request number (e.g.: 1; blank if non-PR) |
+| SD_TEMPLATE_FULLNAME | Full template name the job is using (e.g.: d2lam/myTemplate; blank if not using template) |
+| SD_TEMPLATE_NAME | Name of the template the job is using (e.g.: myTemplate; blank if not using template) |
+| SD_TEMPLATE_NAMESPACE | Namespace of the template the job is using (e.g.: d2lam; blank if not using template) |
 | SD_TEMPLATE_VERSION | Version of the template the job is using (blank if not using template)|
 | SD_TOKEN | JWT token for the build |
 
@@ -45,10 +47,10 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 
 | Name | Value |
 |------|-------|
-| SD_ROOT_DIR | Location of workspace (e.g.: `/sd/workspace`) |
-| SD_SOURCE_DIR | Location of checked-out code (e.g.: `sd/workspace/src/github.com/d2lam/myPipeline`) |
 | SD_ARTIFACTS_DIR | Location of built/generated files |
 | SD_META_PATH | Location of [metadata](./metadata) |
+| SD_ROOT_DIR | Location of workspace (e.g.: `/sd/workspace`) |
+| SD_SOURCE_DIR | Location of checked-out code (e.g.: `sd/workspace/src/github.com/d2lam/myPipeline`) |
 | SD_SOURCE_PATH | Location of source path which triggered current build. See [Source Paths](./configuration/sourcePaths). |
 
 ## Environment Variables
@@ -61,10 +63,10 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 
 | Name | Value |
 |------|-------|
-| SCM_URL | SCM URL that was checked out |
-| GIT_URL | SCM URL that was checked out with .git appended |
+| SCM_URL | SCM URL that was checked out (e.g.: https://github.com/d2lam/myPipeline) |
+| GIT_URL | SCM URL that was checked out with .git appended (e.g.: https://github.com/d2lam/myPipeline.git) |
 | GIT_BRANCH | Reference for PR or the branch (e.g.: `origin/refs/${PRREF}` or `origin/${BRANCH}`) |
-| SD_BUILD_SHA | The Git commit SHA |
+| SD_BUILD_SHA | The Git commit SHA (e.g.: b5a94cdabf23b21303a0e6d5be5e96bd6300847a) |
 
 ## URLs
 

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -24,7 +24,7 @@ To use a template, define a `screwdriver.yaml`:
 ```yaml
 jobs:
     main:
-        template: template_name@1.3.0
+        template: myNamespace/template_name@1.3.0
 ```
 
 Screwdriver takes the template configuration and plugs it in, so that the `screwdriver.yaml` becomes:
@@ -52,7 +52,7 @@ Example:
 jobs:
     main:
         requires: [~pr, ~commit]
-        template: template_name@1.3.0
+        template: myNamespace/template_name@1.3.0
         steps:
             - preinstall: echo pre-install
             - postinstall: echo post-install
@@ -68,7 +68,7 @@ Example:
 jobs:
     main:
         requires: [~pr, ~commit]
-        template: template_name@1.3.0
+        template: myNamespace/template_name@1.3.0
         steps:
             - install: echo skip installing
 ```
@@ -83,18 +83,19 @@ jobs:
     main:
         requires: [~pr, ~commit]
         image: my_org/my_image:latest
-        template: template_name@1.3.0
+        template: myNamespace/template_name@1.3.0
 ```
 
 ## Creating a template
 
 ### Writing a template yaml
 
-To create a template, create a new repo with a `sd-template.yaml` file. The file should contain a name, version, description, maintainer email, and a config with an image and steps. An optional images directive can be defined to list supported images with a descriptive label.
+To create a template, create a new repo with a `sd-template.yaml` file. The file should contain a namespace, name, version, description, maintainer email, and a config with an image and steps. If no namespace is specified, a 'default' namespace will be applied. An optional images directive can be defined to list supported images with a descriptive label.
 
 Example `sd-template.yaml`:
 
 ```yaml
+namespace: myNamespace
 name: template_name
 version: '1.3'
 description: template for testing
@@ -145,18 +146,18 @@ jobs:
         steps:
             - install: npm install screwdriver-template-main
             - publish: ./node_modules/.bin/template-publish
-            - autotag: ./node_modules/.bin/template-tag --name template_name --tag latest
-            - tag: ./node_modules/.bin/template-tag --name template_name --version 1.3.0 --tag stable
+            - autotag: ./node_modules/.bin/template-tag --name myNamespace/template_name --tag latest
+            - tag: ./node_modules/.bin/template-tag --name myNamespace/template_name --version 1.3.0 --tag stable
         environment:
             SD_TEMPLATE_PATH: ./path/to/template.yaml
     remove:
         steps:
             - install: npm install screwdriver-template-main
-            - remove: ./node_modules/.bin/template-remove --name template_name
+            - remove: ./node_modules/.bin/template-remove --name myNamespace/template_name
     remove_tag:
         steps:
             - install: npm install screwdriver-template-main
-            - remove_tag: ./node_modules/.bin/template-remove-tag --name template_name --tag stable
+            - remove_tag: ./node_modules/.bin/template-remove-tag --name myNamespace/template_name --tag stable
 ```
 
 Create a Screwdriver pipeline with your template repo and start the build to validate and publish it.
@@ -165,4 +166,4 @@ To update a Screwdriver template, make changes in your SCM repository and rerun 
 
 ## Finding templates
 
-To figure out which templates already exist, you can make a `GET` call to the `/templates` endpoint. See the [API documentation](./api) for more information. There should also be a `/templates` endpoint in the UI.
+To figure out which templates already exist, you can make a `GET` call to the `/templates` endpoint. See the [API documentation](./api) for more information. There is also a `/templates` endpoint in the UI.


### PR DESCRIPTION
Adding template env vars and namespace to docs
Adding more examples to env vars as well

_Note: Not sure how detailed I need to be in explaining that they need to use the fullName at all times._

Related to https://github.com/screwdriver-cd/screwdriver/issues/926