### PR TITLE
fix(1084): Add Sonar env vars to guide

### DIFF
--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -9,6 +9,8 @@ toc:
       active: true
     - title: Build Specific
       url: "#build-specific"
+    - title: Plugins
+      url: "#plugins"
     - title: Directories
       url: "#directories"
     - title: Environment Variables
@@ -43,12 +45,21 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 | SD_TEMPLATE_VERSION | Version of the template the job is using (blank if not using template)|
 | SD_TOKEN | JWT token for the build |
 
+## Plugins
+These environment variables may or may not be available depending on what plugins are installed.
+
+#### Coverage (Sonar)
+| Name | Value |
+|------|-------|
+| SD_SONAR_AUTH_URL | Screwdriver API authentication URL that will return a Sonar access token |
+| SD_SONAR_HOST | Sonar host URL |
+
 ## Directories
 
 | Name | Value |
 |------|-------|
 | SD_ARTIFACTS_DIR | Location of built/generated files |
-| SD_META_PATH | Location of [metadata](./metadata) |
+| SD_META_PATH | Location of the [metadata](./metadata) file |
 | SD_ROOT_DIR | Location of workspace (e.g.: `/sd/workspace`) |
 | SD_SOURCE_DIR | Location of checked-out code (e.g.: `sd/workspace/src/github.com/d2lam/myPipeline`) |
 | SD_SOURCE_PATH | Location of source path which triggered current build. See [Source Paths](./configuration/sourcePaths). |


### PR DESCRIPTION
Related to https://github.com/screwdriver-cd/screwdriver/issues/1084