### PR TITLE
fix: Add newline between title and table for external config

### DIFF
--- a/docs/user-guide/configuration/externalConfig.md
+++ b/docs/user-guide/configuration/externalConfig.md
@@ -37,6 +37,7 @@ jobs:
 ```
 
 ## Parent and Child Relationship
+
 | Pipeline      | Permissions   |
 | ------------- |:-------------:|
 | Parent     | All actions on its own pipeline plus create/delete/update/start child pipelines |


### PR DESCRIPTION
Need to add newline to fix markdown:

<img width="848" alt="screen shot 2018-06-19 at 11 13 01 am" src="https://user-images.githubusercontent.com/3230529/41616044-c0940082-73b1-11e8-8983-fdc4d81d48d7.png">

https://docs.screwdriver.cd/user-guide/configuration/externalConfig.html#parent-and-child-relationship