### PR TITLE
fix(1073): Private channel support for Slack notifications

### DIFF
--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -53,10 +53,9 @@ You can configure a list of one or more email addresses to contact. You can also
 ```
 
 ## Slack
-To enable Slack notifications to be sent as a result of build events, invite the `screwdriver-bot` Slack bot to your channel(s) and use the Slack setting in your Screwdriver yaml.
-You can configure a list of one or more Slack channels to notify. You can also configure when to send a Slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`.
+To enable Slack notifications to be sent as a result of build events, invite the `screwdriver-bot` Slack bot to your channel(s) and use the Slack setting in your Screwdriver yaml. Both public and private channels are supported. You can configure a list of one or more Slack channels to notify. 
 
-> **Note**: Currently, only public Slack channels can be notified. Notifications for private channels in Slack [are not yet supported](https://github.com/screwdriver-cd/screwdriver/issues/1073) by Screwdriver.cd.
+You can also configure when to send a Slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`. If no `statuses` field is set, the build will only send notifications for build failures. For a full list of statuses, see the [data-schema](https://github.com/screwdriver-cd/data-schema/blob/c2ea9b0372c6e62cb81e1f50602b751d0b10d547/models/build.js#L83-L96).
 
 #### Example: Multiple Rooms
 


### PR DESCRIPTION
Update docs to remove private channel caveat for Slack notifications

Related to https://github.com/screwdriver-cd/screwdriver/issues/1073