### PR TITLE
add more information about USER_SHELL_BIN

### DIFF
--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -31,6 +31,8 @@ toc:
       url: "#how-do-i-run-a-detached-pipeline"
     - title: How do I mark a build as UNSTABLE?
       url: "#how-do-i-mark-a-build-as-unstable"
+    - title: What shell does Screwdriver use?
+      url: "#what-shell-does-screwdriver-use"
 ---
 
 # Frequently Asked Questions
@@ -116,3 +118,7 @@ To rollback, do the following steps. You'll most likely want to `meta set` an im
 ## How do I mark a build as UNSTABLE?
 
 You can update a build with an `UNSTABLE` status by calling the [API](./api) in a build. You can [clone our example unstable build repository here](https://github.com/screwdriver-cd-test/unstable-build-example).
+
+## What shell does Screwdriver use?
+
+By default, step commands are evaluated with the Bourne shell (`/bin/sh`). You can specify a different shell (such as Bash) with the `USER_SHELL_BIN` [environment variable](./environment-variables).

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -49,12 +49,16 @@ Steps are the list of instructions you want to execute in your build. These shou
 
 You can also specify teardown steps, which will be run regardless of whether the build succeeds or fails. These steps need to be at the end of the job and start with "teardown-"
 
+By default, instructions in steps are executed using the Bourne shell (`/bin/sh`). If you prefer your build to use a different shell, you may specify `USER_SHELL_BIN` in a step's environment. For instance, to use capabilities that Bash provides but the Bourne shell does not, specify `USER_SHELL_BIN: bash` in a job's environment.
+
 #### Example
 ```
 jobs:
     main:
         requires: [~pr, ~commit]
         image: node:8
+        environmment:
+            USER_SHELL_BIN: bash
         steps:
             - step_name: step_command --arg1 --arg2 foo
             - set_env: export FOO=bar
@@ -63,6 +67,7 @@ jobs:
                 pwd                        # prints '/sd/workspace/src/github.com/tkyi/mytest'
                 cd ..
             - pwd: pwd                     # prints '/sd/workspace/src/github.com/tkyi'
+            - bash-only: echo ${FOO%r}     # this will echo ba
             - fail: commanddoesnotexist
             - teardown-mystep1: echo goodbye
             - teardown-mystep2: echo world

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -49,7 +49,7 @@ Steps are the list of instructions you want to execute in your build. These shou
 
 You can also specify teardown steps, which will be run regardless of whether the build succeeds or fails. These steps need to be at the end of the job and start with "teardown-"
 
-By default, instructions in steps are executed using the Bourne shell (`/bin/sh`). If you prefer your build to use a different shell, you may specify `USER_SHELL_BIN` in a step's environment. For instance, to use capabilities that Bash provides but the Bourne shell does not, specify `USER_SHELL_BIN: bash` in a job's environment.
+By default, instructions in steps are executed using the Bourne shell (`/bin/sh`). If you prefer your build to use a different shell, you can configure `USER_SHELL_BIN`. For instance, to use capabilities that Bash provides but the Bourne shell does not, specify `USER_SHELL_BIN: bash` in a job's environment.
 
 #### Example
 ```


### PR DESCRIPTION
If I just wanted to know (like I did yesterday) which shell is used to
run step commands, I wouldn't think to check under environment
variables, although it's useful information there too.