### PR TITLE
fix: revise `file` key setting descriptions.

### DIFF
--- a/docs/ja/user-guide/commands.md
+++ b/docs/ja/user-guide/commands.md
@@ -83,7 +83,7 @@ usage: |
 maintainer: foo@bar.com # コマンドの管理者
 format: binary # コマンドのフォーマット (binary または habitat)
 binary:
-    file: ./foobar.sh # スクリプトやバイナリファイルのリポジトリルートからのパス
+    file: ./foobar.sh # スクリプトやバイナリファイルの sd-command.yaml ファイルからの相対パス
 ```
 
 Remote Habitat の例:
@@ -115,7 +115,7 @@ format: habitat
 habitat:
     package: core/node8 # コマンドで利用する Habitat のパッケージ
     mode: local # Habitat コマンドのモード (remote または local)
-    file: ./foobar.hart # .hart ファイルのリポジトリルートからのパス
+    file: ./foobar.hart # .hart ファイルの sd-command.yaml ファイルからの相対パス
     command: node # 実行可能なコマンド
 ```
 

--- a/docs/ja/user-guide/commands.md
+++ b/docs/ja/user-guide/commands.md
@@ -83,7 +83,7 @@ usage: |
 maintainer: foo@bar.com # コマンドの管理者
 format: binary # コマンドのフォーマット (binary または habitat)
 binary:
-    file: ./foobar.sh # スクリプトやバイナリファイルの sd-command.yaml ファイルからの相対パス
+    file: ./foobar.sh # スクリプトやバイナリファイルの sd-command.yaml ファイルからの相対パス、もしくは絶対パス
 ```
 
 Remote Habitat の例:
@@ -115,7 +115,7 @@ format: habitat
 habitat:
     package: core/node8 # コマンドで利用する Habitat のパッケージ
     mode: local # Habitat コマンドのモード (remote または local)
-    file: ./foobar.hart # .hart ファイルの sd-command.yaml ファイルからの相対パス
+    file: ./foobar.hart # .hart ファイルの sd-command.yaml ファイルからの相対パス、もしくは絶対パス
     command: node # 実行可能なコマンド
 ```
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -79,7 +79,7 @@ usage: |
 maintainer: foo@bar.com # Maintainer of the command
 format: binary # Format the command is in (binary, habitat)
 binary:
-    file: ./foobar.sh # Path to script or binary file from sd-command.yaml file or absolute path to it.
+    file: ./foobar.sh # Relative path to script or binary file from sd-command.yaml file or absolute path to it.
 ```
 
 Remote Habitat example:
@@ -109,7 +109,7 @@ format: habitat # Format the command is in (binary, habitat)
 habitat:
     package: core/node8 # Package of the Habitat command
     mode: local # Mode of the Habitat command (remote, local)
-    file: ./foobar.hart # Path to the .hart file from sd-command.yaml file or absolute path to it.
+    file: ./foobar.hart # Relative path to the .hart file from sd-command.yaml file or absolute path to it.
     command: node # Executable of the Habitat command
 ```
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -79,7 +79,7 @@ usage: |
 maintainer: foo@bar.com # Maintainer of the command
 format: binary # Format the command is in (binary, habitat)
 binary:
-    file: ./foobar.sh # Path to script or binary file from sd-command.yaml file
+    file: ./foobar.sh # Path to script or binary file from sd-command.yaml file or absolute path to it.
 ```
 
 Remote Habitat example:
@@ -109,7 +109,7 @@ format: habitat # Format the command is in (binary, habitat)
 habitat:
     package: core/node8 # Package of the Habitat command
     mode: local # Mode of the Habitat command (remote, local)
-    file: ./foobar.hart # Path to the .hart file from sd-command.yaml file
+    file: ./foobar.hart # Path to the .hart file from sd-command.yaml file or absolute path to it.
     command: node # Executable of the Habitat command
 ```
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -79,7 +79,7 @@ usage: |
 maintainer: foo@bar.com # Maintainer of the command
 format: binary # Format the command is in (binary, habitat)
 binary:
-    file: ./foobar.sh # Path to script or binary file from repository root
+    file: ./foobar.sh # Path to script or binary file from sd-command.yaml file
 ```
 
 Remote Habitat example:
@@ -109,7 +109,7 @@ format: habitat # Format the command is in (binary, habitat)
 habitat:
     package: core/node8 # Package of the Habitat command
     mode: local # Mode of the Habitat command (remote, local)
-    file: ./foobar.hart # Path to the .hart file from repository root
+    file: ./foobar.hart # Path to the .hart file from sd-command.yaml file
     command: node # Executable of the Habitat command
 ```
 


### PR DESCRIPTION
## Context

We should revise docs, because the following PR fixes/improves path resolution for a binary file of SD Commands.

## To do

- [x] https://github.com/screwdriver-cd/sd-cmd/pull/30
- [x] update launcher to include the latest `sd-cmd` (https://github.com/screwdriver-cd/launcher/pull/223)
