### PR TITLE
fix: link entity in ENV to domain model page

### DIFF
--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -34,7 +34,7 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 
 | Name | Description |
 |------|-------|
-| SD_BUILD_ID | [Build](../about/appendix/domain#build) number (e.g.: `1`, `2`, etc) |
+| SD_BUILD_ID | The ID of the [build](../about/appendix/domain#build) |
 | SD_EVENT_ID | The ID of the [event](../about/appendix/domain#event) |
 | SD_JOB_ID | The ID of the [job](../about/appendix/domain#job) |
 | SD_JOB_NAME | Job name (e.g.: `main`) |

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -34,11 +34,11 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 
 | Name | Description |
 |------|-------|
-| SD_BUILD_ID | Build number (e.g.: `1`, `2`, etc) |
-| SD_EVENT_ID | The ID of the event |
-| SD_JOB_ID | The ID of the job |
+| SD_BUILD_ID | [Build](../about/appendix/domain#build) number (e.g.: `1`, `2`, etc) |
+| SD_EVENT_ID | The ID of the [event](../about/appendix/domain#event) |
+| SD_JOB_ID | The ID of the [job](../about/appendix/domain#job) |
 | SD_JOB_NAME | Job name (e.g.: `main`) |
-| SD_PIPELINE_ID | The ID of the pipeline |
+| SD_PIPELINE_ID | The ID of the [pipeline](../about/appendix/domain#pipeline) |
 | SD_PIPELINE_NAME | The name of the pipeline (e.g.: `d2lam/myPipeline`) |
 | SD_PULL_REQUEST | Pull Request number (e.g.: `1`; blank if non-PR) |
 | SD_TEMPLATE_FULLNAME | Full template name the job is using (e.g.: `d2lam/myTemplate`; blank if not using template) |


### PR DESCRIPTION
link entity in ENV to domain model page to provide detailed description