### PR TITLE
Remove beta prefix for cpu/ram resources

### DIFF
--- a/docs/ja/user-guide/configuration/annotations.md
+++ b/docs/ja/user-guide/configuration/annotations.md
@@ -26,7 +26,7 @@ jobs:
     main: *bar                  # アノテーションで定義したアンカーを参照
                                 # mainジョブでnode:8イメージを指定することになります
     annotations:
-        screwdriver.cd/cpu: HIGH                      # CPUのHIGHリソースを指定
+        screwdriver.cd/cpu: HIGH                           # CPUのHIGHリソースを指定
         screwdriver.cd/buildPeriodically: H H(4-7) * * *   # 毎日午前4時から午前7時(UTC)の間にジョブを実行します
 ```
 

--- a/docs/ja/user-guide/configuration/annotations.md
+++ b/docs/ja/user-guide/configuration/annotations.md
@@ -26,7 +26,7 @@ jobs:
     main: *bar                  # アノテーションで定義したアンカーを参照
                                 # mainジョブでnode:8イメージを指定することになります
     annotations:
-        beta.screwdriver.cd/cpu: HIGH                      # CPUのHIGHリソースを指定
+        screwdriver.cd/cpu: HIGH                      # CPUのHIGHリソースを指定
         screwdriver.cd/buildPeriodically: H H(4-7) * * *   # 毎日午前4時から午前7時(UTC)の間にジョブを実行します
 ```
 
@@ -37,7 +37,7 @@ jobs:
 アノテーション | 値 | 説明
 --- | --- | ---
 beta.screwdriver.cd/executor | クラスタ管理者にご確認ください | ビルドの実行環境を指定します。VMやkubernetesポッド、dockerコンテナ、Jenkinsエージェントなどでビルドを実行するように設定できます。
-beta.screwdriver.cd/cpu | `MICRO` / `LOW` / `HIGH` | `k8s` executorを利用する場合、ユーザーは 0.5 (`MICRO`)、2 (`LOW`)、6 (`HIGH`) CPUの中から選択可能です。<br>`k8s-vm` executorを利用する場合は、1 (`MICRO`)、2 (`LOW`)、6 (`HIGH`) CPU の中から選択可能です。<br>いずれの場合もデフォルト値は`LOW`となります。
-beta.screwdriver.cd/ram | `MICRO` / `LOW` / `HIGH` | `k8s` executorを利用する場合、ユーザーは 1 GB (`MICRO`)、 2 GB (`LOW`)、12 GB (`HIGH`) RAMの中から選択可能です。<br>`k8s-vm` executorを利用する場合は、1 GB (`MICRO`)、2 GB (`LOW`)、12 GB (`HIGH`) RAMの中から選択可能です。<br>いずれの場合もデフォルト値は`LOW`となります。
+screwdriver.cd/cpu | `MICRO` / `LOW` / `HIGH` | `k8s` executorを利用する場合、ユーザーは 0.5 (`MICRO`)、2 (`LOW`)、6 (`HIGH`) CPUの中から選択可能です。<br>`k8s-vm` executorを利用する場合は、1 (`MICRO`)、2 (`LOW`)、6 (`HIGH`) CPU の中から選択可能です。<br>いずれの場合もデフォルト値は`LOW`となります。
+screwdriver.cd/ram | `MICRO` / `LOW` / `HIGH` | `k8s` executorを利用する場合、ユーザーは 1 GB (`MICRO`)、 2 GB (`LOW`)、12 GB (`HIGH`) RAMの中から選択可能です。<br>`k8s-vm` executorを利用する場合は、1 GB (`MICRO`)、2 GB (`LOW`)、12 GB (`HIGH`) RAMの中から選択可能です。<br>いずれの場合もデフォルト値は`LOW`となります。
 beta.screwdriver.cd/timeout | 時間(分) | ビルドがタイムアウトとなる時間(分)を指定できます。デフォルト値は`90` 分です。
 screwdriver.cd/buildPeriodically | CRON表記 <br>例: `H 0 * * *`<br><br>**注意:** 共有リソースへ急激に負荷がかかることを避けるため、「分」のフィールドは常に'H'(ハッシュを表す)を指定します。(実行頻度は最高でも1時間に1回です)<br>CRON表記については以下で確認ができます。https://crontab.guru/ | cron表記にしたがって定期的にジョブを実行します。

--- a/docs/ja/user-guide/configuration/index.md
+++ b/docs/ja/user-guide/configuration/index.md
@@ -28,8 +28,8 @@ toc:
     <a href="#annotations"><span class="key">annotations</span>:
     <span class="key">beta.screwdriver.cd/my-cluster-annotation</span>: <span class="value">my-data</span></a>
         <a href="#executor"><span class="key">beta.screwdriver.cd/executor</span>: <span class="value">k8s-vm</span></a>
-        <a href="#cpu"><span class="key">beta.screwdriver.cd/cpu</span>: <span class="value">HIGH</span></a>
-        <a href="#ram"><span class="key">beta.screwdriver.cd/ram</span>: <span class="value">LOW</span></a>
+        <a href="#cpu"><span class="key">screwdriver.cd/cpu</span>: <span class="value">HIGH</span></a>
+        <a href="#ram"><span class="key">screwdriver.cd/ram</span>: <span class="value">LOW</span></a>
 <a href="#jobs"><span class="key">jobs</span>:</a>
       <span class="key">main</span>:
         <a href="#requires"><span class="key">requires</span>: <span class="value">[~pr, ~commit, ~sd@123:main]</span></a>

--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -28,8 +28,8 @@ You can access information about properties by hovering over the property name.
     <a href="#annotations"><span class="key">annotations</span>:
     <span class="key">beta.screwdriver.cd/my-cluster-annotation</span>: <span class="value">my-data</span></a>
         <a href="#executor"><span class="key">beta.screwdriver.cd/executor</span>: <span class="value">k8s-vm</span></a>
-        <a href="#cpu"><span class="key">beta.screwdriver.cd/cpu</span>: <span class="value">HIGH</span></a>
-        <a href="#ram"><span class="key">beta.screwdriver.cd/ram</span>: <span class="value">LOW</span></a>
+        <a href="#cpu"><span class="key">screwdriver.cd/cpu</span>: <span class="value">HIGH</span></a>
+        <a href="#ram"><span class="key">screwdriver.cd/ram</span>: <span class="value">LOW</span></a>
 <a href="#jobs"><span class="key">jobs</span>:</a>
       <span class="key">main</span>:
         <a href="#requires"><span class="key">requires</span>: <span class="value">[~pr, ~commit, ~sd@123:main]</span></a>


### PR DESCRIPTION
Align with http://blog.screwdriver.cd/post/178672849772/configurable-build-resources