### PR TITLE
feat: Document GIT_SHALLOW_CLONE environment variable

### DIFF
--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -57,6 +57,7 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 |------|---------------|-------------|
 | SD_ZIP_ARTIFACTS | false | **Options:** (`true`/`false`) <br><br>Compresses and uploads artifacts in a single ZIP file.<br><br>**Use case:** If you're using Amazon S3 for your store, the zip file can be unzipped on the store end using AWS Lambda. Reduces upload time when your build has a lot of artifacts but there's an upper limit to the size and number of files in the zip file you upload, since the compute resources on Lambda are limited per build. If the upload fails, it's likely that you have more artifacts or that the zip is larger than Lambda can handle.<br><br>**Note:** Consult with your cluster admin to see if this option is available. |
 | USER_SHELL_BIN | sh | The user shell bin to run the build in. Can also be the full path such as `/bin/bash`.
+| GIT_SHALLOW_CLONE | true | **Options:** (`true`/`false`) <br><br>Shallow clones source repository with a depth of 50 commits.
 
 ## Plugins
 These environment variables may or may not be available depending on what plugins are installed.


### PR DESCRIPTION
## Context  
Repositories containing huge commit trees take noticeably longer to clone. In most use cases the entire commit tree is not needed in a Screwdriver job. As such, we can make use of git shallow cloning to only clone a subset of the commit tree and thus improve performance.

## Objectives
- Allow users to opt out by setting the environment variable `GIT_SHALLOW_CLONE` to `false`

## References
https://github.com/screwdriver-cd/screwdriver/projects/4#card-14436792
https://github.com/screwdriver-cd/scm-github/pull/106