### PR TITLE
docs: Fix typo in job configuration example

### DIFF
--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -57,7 +57,7 @@ jobs:
     main:
         requires: [~pr, ~commit]
         image: node:8
-        environmment:
+        environment:
             USER_SHELL_BIN: bash
         steps:
             - step_name: step_command --arg1 --arg2 foo


### PR DESCRIPTION
There's a typo in the "Steps" example of the User Guide -> Job Configuration,
which results in a failure when trying to run a job with this exact example.