### PR TITLE
fix: switch k8s api endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -35,7 +35,7 @@ jobs:
           DOCKER_REPO: screwdrivercd/guide
           K8S_CONTAINER: guide
           K8S_IMAGE: screwdrivercd/guide
-          K8S_HOST: api.k8s.screwdriver.cd
+          K8S_HOST: api.ossd.k8s.screwdriver.cd
           K8S_DEPLOYMENT: sdguide
       secrets:
           - K8S_TOKEN


### PR DESCRIPTION
 Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.