### PR TITLE
fix: correct sonar example

### DIFF
--- a/docs/ja/user-guide/configuration/code-coverage.md
+++ b/docs/ja/user-guide/configuration/code-coverage.md
@@ -27,7 +27,7 @@ SonarQube を使用するために、`sonar-project.properties` ファイルを�
 
 以下は [Javascript example](https://github.com/screwdriver-cd-test/sonar-coverage-example-javascript) の `sonar-project.properties` の例です:
 ```
-sonar.sources=lib
+sonar.sources=index.js
 sonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info
 ```
 

--- a/docs/user-guide/configuration/code-coverage.md
+++ b/docs/user-guide/configuration/code-coverage.md
@@ -27,7 +27,7 @@ To use SonarQube, add a `sonar-project.properties` file in the root of your sour
 
 Example `sonar-project.properties` file from our [Javascript example](https://github.com/screwdriver-cd-test/sonar-coverage-example-javascript):
 ```
-sonar.sources=lib
+sonar.sources=index.js
 sonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info
 ```
 


### PR DESCRIPTION
- correct sonar example: the repo only has index.js file not `lib` folder

https://github.com/screwdriver-cd-test/sonar-coverage-example-javascript