### PR TITLE
change the instruction related musl

### DIFF
--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -93,7 +93,7 @@ Individual pipelines may be removed by clicking the Delete icon on the Options t
 This is caused by a variety of reasons including cluster setup issue like hyperd down (if using executor vm) or a problem with your build image etc. Fixing this issue
 requires different approaches based on what layer it's failing.
 
-1. `/opt/sd/launch: not found` This issue affects Alpine based images because it uses musl instead of glibc. Workaround is to create the following symlink `mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2` when creating your Docker image.
+1. `/opt/sd/launch: not found` This issue affects Alpine based images because it uses musl instead of glibc. Workaround is to create the following symlink `mkdir /lib64 && ln -s /lib/ld-musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2` when creating your Docker image.
 1. [A bug in hyperd](https://github.com/screwdriver-cd/screwdriver/issues/1081) sometimes causes images with `VOLUME` defined to fail to launch consistently in some certain nodes. One of these images is `gradle:jdk8`. The current workaround is to use other docker images, or to rebuild the gradle image using [this Dockerfile](https://github.com/keeganwitt/docker-gradle/blob/64a348e79cbe0bc8acb9da9062f75aca02bf3023/jdk8/Dockerfile) but excluding the `VOLUME` line.
 
 ## How do I rollback?
@@ -144,6 +144,4 @@ If shallow cloning is left enabled and you wish to push back to your git reposit
 
 Screwdriver has no restriction on build container image. However it should have at the minimum `curl` && `openssh` installed.
 
-Also, if the `image` is Alpine-based, an extra workaround is required in the form of the following symlink. `mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2`
-
-Alternatively you can also try setting `LD_LIBRARY_PATH` to include musl library paths.
+Also, if the `image` is Alpine-based, an extra workaround is required in the form of the following symlink. `mkdir -p /lib64 && ln -s /lib/ld-musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2`


### PR DESCRIPTION
* libc.musl-x86_64.so.1 is C library, so use `ld-musl-x86_64.so.1`, dynamic linker path instead.
* remove sentence about LD_LIBRARY_PATH because it checked by dynamic linker, so it doesn't resolve the dynamic-linker problem.

**Issue #, if available:**

**Description of changes:**
First change: change the instruction about the dynamic linker.
On current musl version, `libc.musl-x86_64.so.1` is a symlink to `ld-musl-x86_64.so.1`.
but we should use `ld-musl-x86_64.so.1` to keep real compatibility.

You can check `interpreter XXXX` with `file` command:
```
bash-4.4# file /bin/busybox
/bin/busybox: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, stripped
bash-4.4# file store-cli_linux_amd64
store-cli_linux_amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=_yCZXYF9tB2B-YA0h_NQ/DvvRwllh57uJdn86b6rb/h0CHi6t4FQhXKU61mYKI/lCi8VJ6b8RorVPVqtGto, stripped
```

Second change: drop LD_LIBRARY_PATH from the instruction.
http://man7.org/linux/man-pages/man8/ld.so.8.html
The dynamic linker uses LD_LIBRARY_PATH for resolving shared library path, but the first problem for alpine is that the (Linux) kernel can't find dynamic linker.
So I think It isn't any alternative for this problem.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.