### PR TITLE
fix: Add Twitter and blog

### DIFF
--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -84,3 +84,5 @@
           url: "/about/contributing/index"
     - title: "Support"
       url: "/about/support"
+    - title: "Announcements"
+      url: "/about/announcements"

--- a/docs/about/announcements.md
+++ b/docs/about/announcements.md
@@ -1,0 +1,21 @@
+---
+layout: main
+title: Announcements
+category: About
+menu: menu
+toc:
+    - title: Announcements
+      url: "#announcements"
+      active: true
+    - title: Blog
+      url: "#blog"
+    - title: Twitter
+      url: "#twitter"
+---
+# Announcements
+
+## Blog
+When new features are rolled out, we write about them in our blog. You can also find the required Docker images for these new features in our posts. Follow us on Tumblr at [blog.screwdriver.cd](https://blog.screwdriver.cd) for updates!
+
+## Twitter
+We use Twitter for meetup and conference updates and blog updates. Follow us at [twitter.com/screwdrivercd](https://twitter.com/screwdrivercd).


### PR DESCRIPTION
## Context

Adding Twitter and blog to guide

<img width="1255" alt="Screen Shot 2019-06-26 at 1 57 31 PM" src="https://user-images.githubusercontent.com/3230529/60215188-ebda4500-981b-11e9-9bd0-e95ed967881c.png">


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
