### PR TITLE
fix: add doc for parent directory when using external config

### DIFF
--- a/docs/user-guide/configuration/externalConfig.md
+++ b/docs/user-guide/configuration/externalConfig.md
@@ -43,6 +43,8 @@ jobs:
 | Parent     | All actions on its own pipeline plus create/delete/update/start child pipelines |
 | Child      | All actions on its own pipeline except delete/update itself; also, secrets are inherited from the parent pipeline by default but can be overwritten |
 
+Builds for child pipeline will have access to parent pipeline's repository at [`$SD_CONFIG_DIR`](../environment-variables#directories).
+
 ## User Interface
 Parent pipeline UI:
 ![External config parent](../assets/external-config.png)


### PR DESCRIPTION
## Context

Clarify in external config doc on where parent repository code is.

## Objective

Clarify docs

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
