### PR TITLE
fix: Install wget properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ WORKDIR /usr/src/app
 
 # Install guide
 RUN set -x \
+  && apk update \
   # Missing https for some magical reason; need build tools for jekyll install
   && apk add --no-cache --update ca-certificates build-base \
   # You know you're using a lean image when you need to install wget
-  && apk add --virtual wget \
+  && apk add --no-cache ca-certificates wget \
+  && update-ca-certificates
   # Fetch the latest Guide release
   && wget -q -O - https://github.com/screwdriver-cd/guide/releases/latest \
       | egrep -o '/screwdriver-cd/guide/releases/download/v[0-9.]*/guide.tgz' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN set -x \
   # Missing https for some magical reason; need build tools for jekyll install
   && apk add --no-cache --update ca-certificates build-base \
   # You know you're using a lean image when you need to install wget
-  && apk add --no-cache ca-certificates wget \
-  && update-ca-certificates
+  && apk add --no-cache --virtual ca-certificates wget \
   # Fetch the latest Guide release
   && wget -q -O - https://github.com/screwdriver-cd/guide/releases/latest \
       | egrep -o '/screwdriver-cd/guide/releases/download/v[0-9.]*/guide.tgz' \


### PR DESCRIPTION
## Context

The Docker build has been failing for the guide for the last 2 months (https://cd.screwdriver.cd/pipelines/27/events). The failure message has to do with wget not getting installed properly:
```
+ wget '--base=http://github.com/' -i - -O guide.tgz
wget: unrecognized option: base=http://github.com/
+ egrep -o '/screwdriver-cd/guide/releases/download/v[0-9.]*/guide.tgz'
+ wget -q -O - https://github.com/screwdriver-cd/guide/releases/latest
BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.
Usage: wget [-c|--continue] [--spider] [-q|--quiet] [-O|--output-document FILE]
[--header 'header: value'] [-Y|--proxy on/off] [-P DIR]
[-S|--server-response] [-U|--user-agent AGENT] [-T SEC] URL...
Retrieve files via HTTP or FTP
--spider	Only check URL existence: $? is 0 if exists
-c	Continue retrieval of aborted transfer
-q	Quiet
-P DIR	Save to DIR (default .)
-S Show server response
-T SEC	Network read timeout is SEC seconds
-O FILE	Save to FILE ('-' for stdout)
-U STR	Use STR for User-Agent header
-Y on/off	Use proxy
```
This is a known issue with Alpine apk: https://github.com/Yelp/dumb-init/issues/73

## Objective

This PR installs wget properly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
