### PR TITLE
fix: Clarify env var limitations

### DIFF
--- a/docs/user-guide/configuration/environment.md
+++ b/docs/user-guide/configuration/environment.md
@@ -14,20 +14,23 @@ A set of key/value pairs for environment variables that need to available in a b
 
 ## Limitations
 - Nested environment variables do not work under the `environment` section.
+- Environment variables are evaluated in the order in which they were declared: `template` > `shared` > `jobs`.
 
 #### Example
 
-```
+```yaml
 shared:
     template: example/mytemplate@stable
     environment:
         FOO: bar
-        MYVAR: hello        # This will set MYVAR=hello in all builds
+        MYVAR: ${FOO}        # This will set MYVAR=bar in all builds
 jobs:
     main:
         requires: [~pr, ~commit]
         environment:
-            FOO: baz        # This will set FOO=baz in the build
-    main2:                  # This will set FOO=bar in the build
+            FOO: baz        # This will set FOO=baz, MYVAR=baz in the build
+    main2:
         requires: [main]
+        environment:        # Due to the above shared section, FOO=bar in the build
+            MYVAR: hello    # This will set MYVAR=hello in the build
 ```


### PR DESCRIPTION
## Context

Env vars are processed in the order they are declared. Even if a user defines them again later, they will be overwritten in place.

## Objective

This PR adds docs to note that caveat.

## References

Related to https://github.com/screwdriver-cd/config-parser/pull/90

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
