### PR TITLE
Support for SD_META_DIR environment variable

### DIFF
--- a/docs/ja/user-guide/environment-variables.md
+++ b/docs/ja/user-guide/environment-variables.md
@@ -85,6 +85,7 @@ SD_TOKEN | ビルド用の JWT トークン
 --- | ---
 SD_SOURCE_DIR | チェックアウトされたコードのディレクトリ
 SD_ARTIFACTS_DIR | ビルド･生成されたファイルのディレクトリ <br><br>**注意**: ビルドが`ABORTED`で無い場合に、`sd-teardown-screwdriver-artifact-bookend`ステップでこのディレクトリからストアへアップロードされます。
+SD_META_DIR | [メタデータ](./metadata)ディレクトリのパス
 SD_META_PATH | [メタデータ](./metadata)ファイルのパス
 SD_ROOT_DIR | ワークスペースのディレクトリ (例: `/sd/workspace`)
 SD_SOURCE_DIR | チェックアウトされたコードのディレクトリ (例: `/sd/workspace/src/github.com/d2lam/myPipeline`)

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -81,6 +81,7 @@ These environment variables may or may not be available depending on what plugin
 | Name | Description |
 |------|-------|
 | SD_ARTIFACTS_DIR | Location of built/generated files. <br><br>**Note**: The `sd-teardown-screwdriver-artifact-bookend` step uploads artifacts from this directory into the Store unless the build is `ABORTED`. |
+| SD_META_DIR | Location of the [metadata](./metadata) directory |
 | SD_META_PATH | Location of the [metadata](./metadata) file |
 | SD_ROOT_DIR | Location of workspace (e.g.: `/sd/workspace`) |
 | SD_SOURCE_DIR | Location of checked-out code (e.g.: `sd/workspace/src/github.com/d2lam/myPipeline`) |


### PR DESCRIPTION
## Context

Implementation of https://github.com/screwdriver-cd/screwdriver/issues/1866

## Objective

One less thing to worry about when running jobs and expecting workspace containment

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.