### PR TITLE
fix: ensure bundler is installed for corresponding ruby, like v2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,4 +61,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.5
+   2.1.4


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Build used to work like: https://cd.screwdriver.cd/pipelines/27/builds/156430/steps/bundle_install

![image](https://user-images.githubusercontent.com/15989893/72303462-32f61f00-3622-11ea-8da9-f51ac5a91f11.png)

However, today 1/13/2020, the container `ruby:2` tag is updated to use ruby 2.7, and result in some `gemfile.lock` outdated. See screenshot:

![image](https://user-images.githubusercontent.com/15989893/72303500-591bbf00-3622-11ea-91aa-c301a79206ba.png)

## Objective
This PR updates the `gemfile.lock` to unblock `bundler installation`.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/kufu/tsubaki/commit/dd1a1866e70674b9c2b6a12339d711e6fc311565

https://hub.docker.com/_/ruby
![image](https://user-images.githubusercontent.com/15989893/72303833-62f1f200-3623-11ea-9c2f-43c031df57d6.png)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
