### PR TITLE
fix: Fix env var name according to yaml example

### DIFF
--- a/docs/user-guide/configuration/environment.md
+++ b/docs/user-guide/configuration/environment.md
@@ -44,4 +44,4 @@ shared:
        X.Y: "Z"
 ```
 
-Then `process.env.REGION.INSTANCE` won't work, and you must use `process.env['REGION.INSTANCE']` dot notation to access as well in nodejs, or other programming languages.
+Then `process.env.X.Y` won't work, and you must use `process.env['X.Y']` dot notation to access as well in nodejs, or other programming languages.


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`REGION.INSTANCE` environment variable is not used in the yaml example of this page.
Fix environment variable name to `X.Y` according to yaml example.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix environment variable name to `X.Y` according to yaml example.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
