### PR TITLE
docs: Update store configuration to take S3 default ACL

### DIFF
--- a/docs/cluster-management/configure-store.md
+++ b/docs/cluster-management/configure-store.md
@@ -96,6 +96,7 @@ We have two methods of storing artifacts right now: - `memory` - In-memory store
 | S3_REGION            | *none*  | Amazon S3 region                               |
 | S3_BUCKET            | *none*  | Amazon S3 bucket that you have write access to |
 | S3_ENDPOINT          | *none*  | Custom endpoint for Amazon S3 compatible API   |
+| S3_DEFAULT_ACL       | public-read | default ACL for putting objects in your s3 bucket |
 
 ```yaml
 # config/local.yaml


### PR DESCRIPTION
## Context

Currently the screwdriver store uses catbox-s3 which by default will attempt to establish the s3 cache using public-read ACL. This is a no go for private repos, and private clusters as far as my company is concerned. 

## Objective

Allow the ACL setting to be passed through to catbox-s3, such that a screwdriver cluster manager can override the ACL from public-read to private. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/1934


## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
