### PR TITLE
docs: use https protocol

### DIFF
--- a/docs/cluster-management/developing-locally.md
+++ b/docs/cluster-management/developing-locally.md
@@ -40,9 +40,9 @@ See screenshot below
 * [store](https://github.com/screwdriver-cd/store)
 
 ```bash
-git clone git@github.com:screwdriver-cd/ui.git
-git clone git@github.com:screwdriver-cd/screwdriver.git
-git clone git@github.com:screwdriver-cd/store.git
+git clone https://github.com/screwdriver-cd/ui.git
+git clone https://github.com/screwdriver-cd/screwdriver.git
+git clone https://github.com/screwdriver-cd/store.git
 ```
 
 ## Step 4: Add local config files for these three repos


### PR DESCRIPTION
## Context
Replace the SSH protocol with the HTTPS protocol.

## Objective
If you use the SSH protocol, you must be a member of the repositories. 
Because the repositories are public，everyone can clone them with HTTPS protocol.

## References
none

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
