### PR TITLE
fix(1314): Add usage of Secrets in sd-local

### DIFF
--- a/docs/ja/user-guide/local.md
+++ b/docs/ja/user-guide/local.md
@@ -162,6 +162,14 @@ buildコマンドには以下のオプションを設定することができま
 - 空行は無視されます
 - 引用符に特殊な処理はされません。値の一部とみなされます
 
+### Secretsの利用方法
+sd-localでは[Secrets](configuration/secrets)を利用する場合、環境変数として`--env`もしくは`--env-file`オプションによって直接指定する必要があります。
+
+```
+$ sd-local build <job name> --env <secret name>=<secret value>
+```
+
+
 ## 環境変数の一覧
 sd-localのビルド内では、以下の環境変数が利用できます。デフォルト値に`-`が設定されているものは、Screwdriver上でのビルドと同様のため、[環境変数](environment-variables)を参照してください。
 

--- a/docs/ja/user-guide/local.md
+++ b/docs/ja/user-guide/local.md
@@ -163,7 +163,7 @@ buildコマンドには以下のオプションを設定することができま
 - 引用符に特殊な処理はされません。値の一部とみなされます
 
 ### Secretsの利用方法
-sd-localでは[Secrets](configuration/secrets)を利用する場合、環境変数として`--env`もしくは`--env-file`オプションによって直接指定する必要があります。
+sd-localでは[Secrets](configuration/secrets)を利用する場合、`screwdriver.yaml`の`secrets`の項目で設定していた値を環境変数として`--env`もしくは`--env-file`オプションによって直接指定する必要があります。
 
 ```
 $ sd-local build <job name> --env <secret name>=<secret value>

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -182,6 +182,12 @@ Note:
 - Blank lines are ignored.
 - There is no special handling of quotation marks. This means that they are part of the VAL.
 
+### How to use Secrets
+You can use [Secrets](configuration/secrets) by passing as environment variables with `--env` or `--env-file` option.
+
+```
+$ sd-local build <job name> --env <secret name>=<secret value>
+```
 
 ## List of environment variables
 You can use the following environment variables in sd-local build. The default values shown as  `-` are the same defaults as in production Screwdriver. Please refer to [environment variables](environment-variables) for more details.

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -183,7 +183,7 @@ Note:
 - There is no special handling of quotation marks. This means that they are part of the VAL.
 
 ### How to use Secrets
-You can use [Secrets](configuration/secrets) by passing as environment variables with `--env` or `--env-file` option.
+You can use [Secrets](configuration/secrets) by passing `secrets` in `screwdriver.yaml` as environment variables with `--env` or `--env-file` option.
 
 ```
 $ sd-local build <job name> --env <secret name>=<secret value>


### PR DESCRIPTION
## Context
Add usage of secrets in sd-local.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->


## References
https://github.com/screwdriver-cd/screwdriver/blob/master/design/sd-local.md#options
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
