### PR TITLE
fix: Fix link path

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -72,7 +72,7 @@ You can preset default environment variables for all builds in your cluster. By 
 | CLUSTER_ENVIRONMENT_VARIABLES | `{ SD_VERSION: 4 }` | Default environment variables for build. For example: `{ SD_VERSION: 4, SCM_CLONE_TYPE: "ssh" }` |
 
 #### Remote join
-By default, [the remote join feature](../user-guide/workflow.md#remote-join) is turned off.
+By default, [the remote join feature](../user-guide/configuration/workflow#remote-join) is turned off.
 
 | Key | Default| Description |
 |:----|:-------|:------------|
@@ -505,7 +505,7 @@ scms:
 
 If users want to use private repo, they also need to set up `SCM_USERNAME` and `SCM_ACCESS_TOKEN` as [secrets](../../user-guide/configuration/secrets) in their `screwdriver.yaml`.
 
-In order to enable [meta PR comments](../user-guide/metadata.md), you’ll need to create a bot user in Git with a personal access token with the `public_repo` scope. In Github, create a new user. Follow instructions to [create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line), set the scope as `public_repo`. Copy this token and set it as `commentUserToken` in your `scms` settings in your [API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269).
+In order to enable [meta PR comments](../user-guide/metadata), you’ll need to create a bot user in Git with a personal access token with the `public_repo` scope. In Github, create a new user. Follow instructions to [create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line), set the scope as `public_repo`. Copy this token and set it as `commentUserToken` in your `scms` settings in your [API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269).
 
 
 ##### Bitbucket.org

--- a/docs/ja/cluster-management/configure-api.md
+++ b/docs/ja/cluster-management/configure-api.md
@@ -74,7 +74,7 @@ auth:
 | CLUSTER_ENVIRONMENT_VARIABLES | `{ SD_VERSION: 4 }` | ビルドのデフォルト環境変数です。例: `{ SD_VERSION: 4, SCM_CLONE_TYPE: "ssh" }` |
 
 #### リモートジョイン
-デフォルトでは、[リモートジョイン機能](../user-guide/workflow.md#リモートジョイン)は無効になっています。
+デフォルトでは、[リモートジョイン機能](../user-guide/configuration/workflow#リモートジョイン)は無効になっています。
 
 | キー | デフォルト | 説明 |
 |:----|:-------|:------------|
@@ -516,7 +516,7 @@ scms:
 
 プライベートレポジトリを使用する場合は、`SCM_USERNAME` と `SCM_ACCESS_TOKEN` を [secrets](../../user-guide/configuration/secrets) として `screwdriver.yaml`に記述する必要があります。
 
-[メタPRコメント](../user-guide/metadata.md)を有効にするためには、Git上でbotユーザを作成し、そのユーザで`public_repo`のスコープを持ったトークンを作成する必要があります。Githubで、新規にユーザを作成し、[create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)の説明に従ってスコープを`public_repo`に設定します。このトークンをコピーして[API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269)内の`scms`の設定内の`commentUserToken`として設定します。
+[メタPRコメント](../user-guide/metadata)を有効にするためには、Git上でbotユーザを作成し、そのユーザで`public_repo`のスコープを持ったトークンを作成する必要があります。Githubで、新規にユーザを作成し、[create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line)の説明に従ってスコープを`public_repo`に設定します。このトークンをコピーして[API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269)内の`scms`の設定内の`commentUserToken`として設定します。
 
 ##### Bitbucket.org
 

--- a/docs/ja/user-guide/configuration/build-cache.md
+++ b/docs/ja/user-guide/configuration/build-cache.md
@@ -60,4 +60,4 @@ jobs:
 サンプルリポジトリ: https://github.com/screwdriver-cd-test/cache-example
 
 ## Notes
-- もしキャッシュが大きくてキャッシュ bookend がメモリオーバーとなるようでしたら、`screwdriver.cd/ram` [アノテーション]((./annotations.md))に `HIGH` を設定するとより多くのメモリがビルドで使用できるようになります。
+- もしキャッシュが大きくてキャッシュ bookend がメモリオーバーとなるようでしたら、`screwdriver.cd/ram` [アノテーション]((./annotations))に `HIGH` を設定するとより多くのメモリがビルドで使用できるようになります。

--- a/docs/ja/user-guide/metadata.md
+++ b/docs/ja/user-guide/metadata.md
@@ -113,7 +113,7 @@ $ meta get example --external sd@123:publish
 
 `/v4/events`への`POST`リクエストのpayloadに設定することでも、イベントメタを設定することができます。
 
-APIのエンドポイントについての詳細は、[APIのドキュメント](./api.md)を参照してください。
+APIのエンドポイントについての詳細は、[APIのドキュメント](./api)を参照してください。
 
 [イベントメタトリガーのサンプルリポジトリ](https://github.com/screwdriver-cd-test/event-meta-trigger-example)や、それに対応した[イベントメタのサンプルリポジトリ](https://github.com/screwdriver-cd-test/event-meta-example)も参考にしてください。
 

--- a/docs/ja/user-guide/templates.md
+++ b/docs/ja/user-guide/templates.md
@@ -277,7 +277,7 @@ _注意: イベント作成時にテンプレートが展開されるので、�
 
 ## ビルドキャッシュを利用する
 
-[ビルドキャッシュ](./configuration/build-cache.md)を利用するには、[store-cliコマンド](https://github.com/screwdriver-cd/store-cli)をステップ内で使用します。例えば、`node_modules/`フォルダをキャッシュする場合、`npm install`を実行するステップの前にキャッシュをダウンロードするステップを設定し、その後キャッシュをアップロードする別のステップを指定します。`teardown-`プレフィックスを使用して、キャッシュをアップロードするステップをteardownに移動することもできます。
+[ビルドキャッシュ](./configuration/build-cache)を利用するには、[store-cliコマンド](https://github.com/screwdriver-cd/store-cli)をステップ内で使用します。例えば、`node_modules/`フォルダをキャッシュする場合、`npm install`を実行するステップの前にキャッシュをダウンロードするステップを設定し、その後キャッシュをアップロードする別のステップを指定します。`teardown-`プレフィックスを使用して、キャッシュをアップロードするステップをteardownに移動することもできます。
 
 ```yaml
 config:

--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -60,4 +60,4 @@ In the above example, the pipeline-scoped `.gradle` cache can be accessed under 
 Example repo: https://github.com/screwdriver-cd-test/cache-example
 
 ## Notes
-- If your cache is large and the cache bookend runs out of memory, you can set the `screwdriver.cd/ram` [annotation](./annotations.md) to `HIGH` to provide more memory to the build.
+- If your cache is large and the cache bookend runs out of memory, you can set the `screwdriver.cd/ram` [annotation](./annotations) to `HIGH` to provide more memory to the build.

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -107,7 +107,7 @@ Notes:
 
 You can also prepopulate event meta by configuring the payload of the `POST` request to `/v4/events`.
 
-See the [API docs](./api.md) for more information on API endpoints.
+See the [API docs](./api) for more information on API endpoints.
 See the [event meta trigger example repo](https://github.com/screwdriver-cd-test/event-meta-trigger-example) and corresponding [event meta example repo](https://github.com/screwdriver-cd-test/event-meta-example) for reference.
 
 ### Pull Request Comments

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -263,7 +263,7 @@ _Note: You cannot test your template in the same pipeline, as template step expa
 
 ## Using the build cache
 
-To use the [build cache feature](./configuration/build-cache.md), the [store-cli command](https://github.com/screwdriver-cd/store-cli) can be invoked in a step. For instance, if you are caching your `node_modules/` folder, you can specify a step before the `npm install` command that downloads the cache and another step afterwards that uploads the cache. You can also move the uploading cache step to a teardown with the `teardown-` prefix.
+To use the [build cache feature](./configuration/build-cache), the [store-cli command](https://github.com/screwdriver-cd/store-cli) can be invoked in a step. For instance, if you are caching your `node_modules/` folder, you can specify a step before the `npm install` command that downloads the cache and another step afterwards that uploads the cache. You can also move the uploading cache step to a teardown with the `teardown-` prefix.
 
 ```yaml
 config:


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
- Link to the remote-join is wrong. Fix to correct path.
- Links to the `.md` cause `404` in the real page (e.g. link to the annotation page in [this page](https://docs.screwdriver.cd/user-guide/configuration/build-cache)) Remove `.md`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Fix link to the remote-join page.
- Remove `.md` from link path.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
