### PR TITLE
fix: Fix Slack and API typos

### DIFF
--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -42,7 +42,7 @@ Swagger model:
 ![Swagger model](./assets/swagger-model.png)
 
 ### With a REST Client
-Use a REST client like [Postman] to make requests against the API. You will need an authorization token. To get an authorization token, login using `/v4/auth/login` and copy the token value when redirected to `/v4/auth/token`. See the [Authorization and Authentication](#authorization-and-authentication) section for more information.
+Use a REST client like [Postman] to make requests against the API. You will need an authorization token. To get an authorization token, login using `/v4/auth/login` and copy the token value when redirected to `/v4/auth/token`. See the [Authorization and Authentication](#authentication-and-authorization) section for more information.
 
 Requests can be made to the API with headers like below:
 ```yaml

--- a/docs/user-guide/configuration/settings.md
+++ b/docs/user-guide/configuration/settings.md
@@ -57,7 +57,7 @@ To enable Slack notifications to be sent as a result of build events, invite the
 
 You can also configure when to send a Slack notification, e.g. when the build status is `SUCCESS` and/or `FAILURE`. If no `statuses` field is set, the build will only send notifications for build failures. For a full list of statuses, see the [data-schema](https://github.com/screwdriver-cd/data-schema/blob/c2ea9b0372c6e62cb81e1f50602b751d0b10d547/models/build.js#L83-L96). You may also choose whether to use the default notification format or a more compact one using the `minimized` setting.
 
-To send data in steps as a notification, [notification meta](https://docs.screwdriver.cd/user-guide/metadata.html#notification) is available.
+To send data in steps as a notification, [notification meta](../metadata#notifications) is available. You can also customize the notification per job.
 
 #### Example: Multiple Rooms
 
@@ -118,3 +118,7 @@ However, if `minimized` is `true`, then the notification will use a format that 
 ```
 
 ![Minimized Slack notification](../assets/slack-minimized-notification.png)
+
+#### Example: Using Metadata
+
+You can also use metadata to set Slack messages. This can be customized for each job. See [notifications section in the metadata page](../metadata#notifications).

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -138,6 +138,8 @@ These settings will result in a Git comment that looks like:
 
 ![PR comment](./assets/pr-comment.png)
 
+_Note: Screwdriver will try to edit the same comment in Git if multiple builds are run on it._
+
 ### Additional Pull Request Checks
 
 > Note: This feature is only available in Github plugin at the moment.
@@ -210,8 +212,7 @@ Result:
 
 ### Notifications
 
-You can customize [notification](./configuration/settings.html#slack) messages with meta.
-Meta keys are different for each notification plugin.
+You can customize [notification](./configuration/settings.html#slack) messages with meta. Meta keys are different for each notification plugin.
 
 #### Basic
 Example screwdriver.yaml notifying with Slack:
@@ -220,13 +221,13 @@ jobs:
   main:
     steps:
       - meta: |
-          meta set notification.slack.message "<@yoshwata> Hello!!"
+          meta set notification.slack.message "<@yoshwata> Hello Meta!"
 ```
 
 Result:
 ![notification-meta](./assets/notification-meta.png)
 
-#### Job based
+#### Job-based
 *Note*: Job-based Slack notification meta data will overwrite the basic notification message. 
 
 Structure of meta variable is `notification.slack.<jobname>.message`, replacing `<jobname>` with the name of the Screwdriver job.


### PR DESCRIPTION
## Context

There are some links missing or broken in the Slack and API pages.

## Objective

This PR fixes some missing links and adds some additional data around Slack notifications.

## References

Related to https://github.com/screwdriver-cd/notifications-slack/pull/24

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
