### PR TITLE
fix(2050): user guide for new config command

### DIFF
--- a/docs/ja/user-guide/local.md
+++ b/docs/ja/user-guide/local.md
@@ -166,7 +166,7 @@ $ sd-local config view
 * cluster2:
     api-url: https://cluster2-api-screwdriver.com
     store-url: https://cluster2-store-screwdriver.com
-    token: yourcluster1token
+    token: yourcluster2token
     launcher:
       version: stable
       image: screwdrivercd/launcher

--- a/docs/ja/user-guide/local.md
+++ b/docs/ja/user-guide/local.md
@@ -93,7 +93,7 @@ builds.log       environment.json steps.json
 ```
 
 # config コマンド
-configコマンドでは、sd-local自体の設定を行います。設定内容は複数環境ごとに保持することができます。  
+configコマンドでは、sd-local自体の設定を行います。設定内容は、環境ごとに複数保持することができます。  
 設定内容は `~/.sdlocal/config` 以下の形式で保存されます。
 
 ```

--- a/docs/ja/user-guide/local.md
+++ b/docs/ja/user-guide/local.md
@@ -8,8 +8,8 @@ toc:
   url: "#sd-localとは？"
 - title: sd-localのインストール
   url: "#sd-localのインストール"
-- title: 簡単な使い方
-  url: "#簡単な使い方"
+- title: クイックスタート
+  url: "#クイックスタート"
 - title: configコマンド
   url: "#configコマンド"
 - title: buildコマンド
@@ -93,13 +93,58 @@ builds.log       environment.json steps.json
 ```
 
 # config コマンド
-configコマンドでは、sd-local自体の設定をkey/valueの形式で行います。
-設定内容は `~/.sdlocal/config` に保存されます。
+configコマンドでは、sd-local自体の設定を行います。設定内容は複数環境ごとに保持することができます。  
+設定内容は `~/.sdlocal/config` 以下の形式で保存されます。
+
+```
+configs:
+  default:
+    api-url: ""
+    store-url: ""
+    token: ""
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+  yourConfigName:
+    api-url: ""
+    store-url: ""
+    token: ""
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+current: default
+```
+
+- `default` はsd-localの初回利用時に自動的に作成されます
+- `current` は現在使用中の設定を表します
 
 ## 使い方
 
+### createサブコマンド
+新規設定を作成します。
+
+```bash
+$ sd-local config create <name>
+```
+
+### deleteサブコマンド
+設定を削除します。
+
+```bash
+$ sd-local config delete <name>
+```
+
+- 現在使用中の設定は削除できません
+
+### useサブコマンド
+現在使用中の設定を変更します。
+
+```bash
+$ sd-local config use <name>
+```
+
 ### setサブコマンド
-key/value形式で設定を行います。ビルドを実行するには`api-url`, `store-url`, `token`を設定する必要があります。  
+現在使用中の設定に対してkey/value形式で設定を行います。ビルドを実行するには`api-url`, `store-url`, `token`を設定する必要があります。  
 利用できる設定内容については、[設定できるキーの一覧](#設定できるキーの一覧)を参照してください。
 
 ```bash
@@ -107,18 +152,25 @@ $ sd-local config set <key> <value>
 ```
 
 ### viewサブコマンド
-現在の設定内容を確認できます。
+設定内容を確認できます。先頭に`*`がついているものが現在使用中の設定です。
 
 ```bash
 $ sd-local config view
+  cluster1:
+    api-url: https://cluster1-api-screwdriver.com
+    store-url: https://cluster1-store-screwdriver.com
+    token: yourcluster1token
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+* cluster2:
+    api-url: https://cluster2-api-screwdriver.com
+    store-url: https://cluster2-store-screwdriver.com
+    token: yourcluster1token
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
 ```
-
-## オプション
-configコマンドには以下のオプションを設定することができます。
-
-|オプション|説明|
-|---|---|
-|--local|カレントディレクトリの`.sdlocal/config`に対して操作します|
 
 ### 設定できるキーの一覧
 
@@ -150,7 +202,6 @@ buildコマンドには以下のオプションを設定することができま
 |--artifacts-dir|ビルド成果物の保存先を指定します（デフォルトは`./sd-artifacts`）|
 |-e, --env|ビルド環境に設定する環境変数を`<key>=<value>` 形式で設定します（複数指定可）|
 |--env-file|ビルド環境に設定する環境変数をファイル形式で設定します（ファイルの形式は[env-fileのフォーマット](#env-fileの形式)を参照）|
-|--local|カレントディレクトリの`.sdlocal/config`の設定をもとにビルドを実行します|
 |-m, --memory|ビルド環境のメモリリソースのリミット値を指定します（b,k,m,gのメモリ単位で指定できます）|
 |--meta|ビルド環境に渡す[メタデータ](metadata)を指定します（JSON形式）例: `"{\"HOGE\": \"FOO\"}"`|
 |--meta-file|ビルド環境に渡す[メタデータ](metadata)をファイルで指定します（JSON形式）|

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -153,7 +153,7 @@ $ sd-local config use <name>
 ```
 
 ### set subcommand
-You can configure a setting in use by key/value format. You must set `api-url`, `store-url`, and `token` in order to execute builds.  
+You can configure the setting currently using by key/value format. You must set `api-url`, `store-url`, and `token` in order to execute builds.  
 Please refer to the [List of keys](#list-of-keys) about available settings.
 ```bash
 $ sd-local config set <key> <value>

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -146,7 +146,7 @@ $ sd-local config delete <name>
 - You can't delete the setting in use
 
 ### use subcommand
-You can switch a setting in use
+You can switch a setting in use.
 
 ```bash
 $ sd-local config use <name>

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -8,8 +8,8 @@ toc:
   url: "#what-is-sd-local-?"
 - title: Installing sd-local
   url: "#installing-sd-local"
-- title: Simple usage
-  url: "#simple-usage"
+- title: Quick start
+  url: "#quick-start"
 - title: config command
   url: "#config-command"
 - title: build command
@@ -101,15 +101,59 @@ builds.log       environment.json steps.json
 
 
 # config command
-You can configure sd-local settings in key/value format by config command.  
-Your settings are stored in `~/.sdlocal/config`.
+You can configure sd-local for multiple environments by config command.  
+Your settings are stored in `~/.sdlocal/config` like below.
 
+```
+configs:
+  default:
+    api-url: ""
+    store-url: ""
+    token: ""
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+  yourConfigName:
+    api-url: ""
+    store-url: ""
+    token: ""
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+current: default
+```
+
+- `default` is created automatically when the first time you use sd-local
+- `current` points the setting which you are currently using
 
 ## Usage
 
 
+### create subcommand
+You can create a new setting.
+
+```bash
+$ sd-local config create <name>
+```
+
+### delete subcommand
+You can delete a setting.
+
+```bash
+$ sd-local config delete <name>
+```
+
+- You can't delete the setting in use
+
+### use subcommand
+You can switch a setting in use
+
+```bash
+$ sd-local config use <name>
+```
+
 ### set subcommand
-You can configure sd-local in key/value format. You must set `api-url`, `store-url`, and `token` in order to execute builds.  
+You can configure a setting in use by key/value format. You must set `api-url`, `store-url`, and `token` in order to execute builds.  
 Please refer to the [List of keys](#list-of-keys) about available settings.
 ```bash
 $ sd-local config set <key> <value>
@@ -117,20 +161,26 @@ $ sd-local config set <key> <value>
 
 
 ### view subcommand
-You can confirm the current settings.
+You can confirm the current settings. The setting starts with `*` is in use.
 
 
 ```bash
 $ sd-local config view
+  cluster1:
+    api-url: https://cluster1-api-screwdriver.com
+    store-url: https://cluster1-store-screwdriver.com
+    token: yourcluster1token
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+* cluster2:
+    api-url: https://cluster2-api-screwdriver.com
+    store-url: https://cluster2-store-screwdriver.com
+    token: yourcluster1token
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
 ```
-
-## Options
-The following options can be used with the config command:
-
-
-|option|description|
-|---|---|
-|--local|Read/Modify `.sdlocal/config` file in current directory|
 
 ### List of keys
 You must set `api-url`, `store-url`, and `token` in order to execute builds.
@@ -167,7 +217,6 @@ The following options can be used with the build command:
 |--artifacts-dir|The build artifacts destination (default: `./sd-artifacts`)|
 |-e, --env|The environment variables in a build environment using `<key>=<value>` format (multiple variables allowed)|
 |--env-file|The environment variables in a build environment using file format (refer to [env-file format](#env-file-format))|
-|--local|Run command with `.sdlocal/config` file in current directory.|
 |-m, --memory|The memory limit of the build environment (can be specified in b, k, m, or g memory unit)|
 |--meta|The [metadata](metadata) used in a build environment using string JSON format: e.g. `"{\"HOGE\": \"FOO\"}"`|
 |--meta-file|The [metadata](metadata) used in build environment using file format|

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -176,7 +176,7 @@ $ sd-local config view
 * cluster2:
     api-url: https://cluster2-api-screwdriver.com
     store-url: https://cluster2-store-screwdriver.com
-    token: yourcluster1token
+    token: yourcluster2token
     launcher:
       version: stable
       image: screwdrivercd/launcher

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -143,7 +143,7 @@ You can delete a setting.
 $ sd-local config delete <name>
 ```
 
-- You can't delete the setting in use
+- You can't delete the setting currently in use
 
 ### use subcommand
 You can switch a setting in use.


### PR DESCRIPTION
## Context
We introduced [new config command in sd-local](https://github.com/screwdriver-cd/sd-local/pull/35) that can handle multiple configurations for multiple SD clusters. 

## Objective
This makes the guide for sd-local latest
- Add `create`, `delete`, `use` subcommands in config command
- Drop `--local` option in config and builds commands

## References
https://github.com/screwdriver-cd/screwdriver/issues/2050

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
