### PR TITLE
fix: Clarify defaults for blockedBySelf and collapse

### DIFF
--- a/docs/cluster-management/configure-queue-service.md
+++ b/docs/cluster-management/configure-queue-service.md
@@ -77,7 +77,7 @@ httpd:
 
 ### Configure Redis Queue
 
-Configure some settings about storing Build Artifacts.
+Configure some settings for setting up the Queue.
 
 | Key                | Required            |  Default              | Description       |
 |:-------------------|:---------------------|:----------------------------------------------------|
@@ -87,6 +87,7 @@ Configure some settings about storing Build Artifacts.
 | REDIS_TLS_ENABLED   | No                   | false                | Redis tls enabled           |
 | REDIS_DB_NUMBER     | No                   | 0                    | Redis db number             |
 | REDIS_QUEUE_PREFIX  | No                   | ''                   | Redis queue prefix          |
+
 ```yaml
 # config/local.yaml
 queue:
@@ -98,4 +99,25 @@ queue:
       tls: false
     database: 0
   prefix: ''
+```
+
+### Configure Blocked By Settings
+
+Configure some settings for [blockedBy](../user-guide/configuration/workflow#blocked-by).
+
+| Key                | Required            |  Default              | Description       |
+|:-------------------|:---------------------|:----------------------------------------------------|
+| PLUGIN_BLOCKEDBY_REENQUEUE_WAIT_TIME      | No                  | 1            | Minutes to wait before re-enqueuing if blocked                 |
+| PLUGIN_BLOCKEDBY_BLOCK_TIMEOUT   | No                   | 120                | Maximum minutes for a job to be blocked before timing out           |
+| PLUGIN_BLOCKEDBY_BLOCKED_BY_SELF     | No                   | true                    | Whether a job will be blocked by itself or not            |
+| PLUGIN_BLOCKEDBY_COLLAPSE  | No                   | true                   | Whether multiple builds run for the same job at the same time will collapse or not         |
+
+```yaml
+# config/local.yaml
+plugins:
+  blockedBy:
+    reenqueueWaitTime: 5
+    blockTimeout: 180
+    blockedBySelf: false
+    collapse: false
 ```

--- a/docs/user-guide/configuration/workflow.md
+++ b/docs/user-guide/configuration/workflow.md
@@ -277,7 +277,7 @@ To have your job blocked by another job, you can use `blockedBy`. It has the sam
 
 Note:
 - Since everything is using OR syntax, you need a tilde (`~`) before each of your job names. We do not support AND logic for blockedBy.
-- To prevent race conditions, a job is always blocked by itself. That means the same job cannot have 2 instances of builds running at the same time.
+- By default, to prevent race conditions, a job is always blocked by itself. That means the same job cannot have 2 instances of builds running at the same time.
 - This feature is only available if your cluster admin configured to use `executor-queue`. Please double check with your cluster admin whether it is supported.
 - This feature does not apply to PR jobs.
 
@@ -308,7 +308,7 @@ Before the job is started, it will check if the start time falls under any of th
 Note:
 - Different from `build_periodically`, `freezeWindows` should not use hashed time therefore *the symbol `H` for hash is disabled.*
 - The combinations of day of week and day of month are usually invalid. Therefore only *one out of day of week and day of month can be specified*. The other field should be set to "?".
-- If multiple builds are triggered during the freeze window, they will be collapsed into one build which will run at the end of the freeze window with the latest commit inside the freeze window.
+- By default, if multiple builds are triggered during the freeze window, they will be collapsed into one build which will run at the end of the freeze window with the latest commit inside the freeze window. You can turn this feature off by setting the `screwdriver.cd/collapseBuilds` [annotation](./annotations) to `false`.
 
 #### Example
 In the following example, `job1` will be frozen during the month of March, `job2` will be frozen on weekends, and `job3` will be frozen from 10:00 PM to 10:59 AM.


### PR DESCRIPTION
## Context

Users don't expect builds to collapse on themselves. It would be nice to make documentation more clear for that feature.

## Objective

This PR adds docs for configuring blockedBy settings in the queue-service and default values.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
