### PR TITLE
fix: Rename environment variables for retry

### DIFF
--- a/docs/cluster-management/configure-build.md
+++ b/docs/cluster-management/configure-build.md
@@ -14,7 +14,7 @@ Configure Screwdriver and Store api timeouts and max retry attempts. These envir
 
 | Name | Description |
 |------|-------|
-| LOGSERVICE_SDAPI_TIMEOUT_SECS | Log service to Screwdriver api - connection timeout in seconds. Default is 20 seconds. |
-| LOGSERVICE_SDAPI_MAXRETRIES | Log service to Screwdriver api - max retry attempts for before giving up. Default is 5 retry attempts. |
-| LOGSERVICE_STOREAPI_TIMEOUT_SECS | Log service to Screwdriver Store api - Connection timeout in seconds. Default is 20 seconds. |
-| LOGSERVICE_STOREAPI_MAXRETRIES | Log service to Screwdriver Store api - max retry attempts before giving up. Default is 5 retry attempts. |
+| SDAPI_TIMEOUT_SECS | Log service and Launcher to Screwdriver api - connection timeout in seconds. Default is 20 seconds. |
+| SDAPI_MAXRETRIES | Log service and Launcher to Screwdriver api - max retry attempts for before giving up. Default is 5 retry attempts. |
+| STOREAPI_TIMEOUT_SECS | Log service to Screwdriver Store api - Connection timeout in seconds. Default is 20 seconds. |
+| STOREAPI_MAXRETRIES | Log service to Screwdriver Store api - max retry attempts before giving up. Default is 5 retry attempts. |

--- a/docs/ja/cluster-management/configure-build.md
+++ b/docs/ja/cluster-management/configure-build.md
@@ -14,7 +14,7 @@ ScrewdriverとStore apiのタイムアウトと最大リトライ数の設定で
 
 | 名称 | 説明 |
 |------|-------|
-| LOGSERVICE_SDAPI_TIMEOUT_SECS | Log service to Screwdriver api - 接続タイムアウト（秒）。デフォルトは20秒。|
-| LOGSERVICE_SDAPI_MAXRETRIES | Log service to Screwdriver api - 最大リトライ数。デフォルトは5回。|
-| LOGSERVICE_STOREAPI_TIMEOUT_SECS | Log service to Screwdriver Store api - 接続タイムアウト（秒）。デフォルトは20秒。|
-| LOGSERVICE_STOREAPI_MAXRETRIES | Log service to Screwdriver Store api - 最大リトライ数。デフォルトは5回。|
+| SDAPI_TIMEOUT_SECS | Log service and Launcher to Screwdriver api - 接続タイムアウト（秒）。デフォルトは20秒。|
+| SDAPI_MAXRETRIES | Log service and Launcher to Screwdriver api - 最大リトライ数。デフォルトは5回。|
+| STOREAPI_TIMEOUT_SECS | Log service to Screwdriver Store api - 接続タイムアウト（秒）。デフォルトは20秒。|
+| STOREAPI_MAXRETRIES | Log service to Screwdriver Store api - 最大リトライ数。デフォルトは5回。|


### PR DESCRIPTION
## Context
Please merge this PR when https://github.com/screwdriver-cd/log-service/pull/35 and https://github.com/screwdriver-cd/launcher/pull/358 are merged.
The environment variables for retry exist separately in launcher and log-service, so we unify them.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- rename `LOGSERVICE_SDAPI_TIMEOUT_SEC` to `SDAPI_TIMEOUT_SECS`
- rename `LOGSERVICE_SDAPI_MAXRETRIES` to `SDAPI_MAXRETRIES`
- add description about Launcher to environment variables for `SDAPI`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/launcher/pull/357#discussion_r444359365
https://github.com/screwdriver-cd/launcher/pull/358
https://github.com/screwdriver-cd/log-service/pull/35
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
