### PR TITLE
docs(1079): Add instructions for adding deploy keys to the pipeline

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -496,11 +496,18 @@ scms:
             email: dev-null@screwdriver.cd # [Optional] Email for code checkout
             commentUserToken: A_BOT_GITHUB_PERSONAL_ACCESS_TOKEN # [Optional] Token for writing PR comments in Github, needs "public_repo" scope
             privateRepo: false # [Optional] Set to true to support private repo; will need read and write access to public and private repos (https://developer.github.com/v3/oauth/#scopes)
+            autoDeployKeyGeneration: false # Set to true to allow automatic generation of private and public deploy keys and add them to the build pipeline and github respectively
 ```
 
 If users want to use private repo, they also need to set up `SCM_USERNAME` and `SCM_ACCESS_TOKEN` as [secrets](../../user-guide/configuration/secrets) in their `screwdriver.yaml`.
 
 In order to enable [meta PR comments](../user-guide/metadata), you’ll need to create a bot user in Git with a personal access token with the `public_repo` scope. In Github, create a new user. Follow instructions to [create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line), set the scope as `public_repo`. Copy this token and set it as `commentUserToken` in your `scms` settings in your [API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269).
+
+###### Deploy Keys
+
+If users want to use deploy keys in their pipeline they have 2 options:
+* Enable automatic generation and handling of deploy keys as a part of the pipeline by using the `autoDeployKeyGeneration` flag in their `config/local.yaml`. With this flag enabled, the user will get an option to actually trigger the generation in the UI.
+* Manually generate the public and private key pair using `openssl genrsa -out jwt.pem 2048` and `openssl rsa -in jwt.pem -pubout -out jwt.pub`. Now add the public key as a deploy key to the repo. The private key needs to be **base64 encoded** and added as a secret `SD_SCM_DEPLOY_KEY` in the pipeline. Refer [secrets](../../user-guide/configuration/secrets) for adding secrets.
 
 
 ##### Bitbucket.org

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -505,7 +505,7 @@ In order to enable [meta PR comments](../user-guide/metadata), you’ll need to 
 
 ###### Deploy Keys
 
-Deploy Keys are repo specific SSH keys. As opposed to Personal Access Tokens. which give user-wide access for all the repositories, deploy keys, because of their limited access, are preferred for private repositories. 
+Deploy Keys are SSH keys that grant access to a single GitHub repository. This key is attached directly to the repository instead of to a personal user account, as opposed to Github personal access tokens. Github personal access tokens give user-wide access for all the repositories while deploy keys, on the other hand, give access to a single repository. Due to their limited access, deploy keys are preferred for private repositories. 
 
 If users want to use deploy keys in their pipeline they have 2 options:
 * Enable automatic generation and handling of deploy keys as a part of the pipeline by setting the `autoDeployKeyGeneration` flag to `true` in their `config/local.yaml`. With this flag enabled, the user will get an option to actually trigger the generation in the UI.

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -496,7 +496,7 @@ scms:
             email: dev-null@screwdriver.cd # [Optional] Email for code checkout
             commentUserToken: A_BOT_GITHUB_PERSONAL_ACCESS_TOKEN # [Optional] Token for writing PR comments in Github, needs "public_repo" scope
             privateRepo: false # [Optional] Set to true to support private repo; will need read and write access to public and private repos (https://developer.github.com/v3/oauth/#scopes)
-            autoDeployKeyGeneration: false # [Optional] Set to true to allow automatic generation of private and public deploy keys and add them to the build pipeline and Github, respectively
+            autoDeployKeyGeneration: false # [Optional] Set to true to allow automatic generation of private and public deploy keys and add them to the build pipeline and Github for repo checkout, respectively
 ```
 
 If users want to use private repo, they also need to set up `SCM_USERNAME` and `SCM_ACCESS_TOKEN` as [secrets](../../user-guide/configuration/secrets) in their `screwdriver.yaml`.

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -496,7 +496,7 @@ scms:
             email: dev-null@screwdriver.cd # [Optional] Email for code checkout
             commentUserToken: A_BOT_GITHUB_PERSONAL_ACCESS_TOKEN # [Optional] Token for writing PR comments in Github, needs "public_repo" scope
             privateRepo: false # [Optional] Set to true to support private repo; will need read and write access to public and private repos (https://developer.github.com/v3/oauth/#scopes)
-            autoDeployKeyGeneration: false # Set to true to allow automatic generation of private and public deploy keys and add them to the build pipeline and github respectively
+            autoDeployKeyGeneration: false # [Optional] Set to true to allow automatic generation of private and public deploy keys and add them to the build pipeline and Github, respectively
 ```
 
 If users want to use private repo, they also need to set up `SCM_USERNAME` and `SCM_ACCESS_TOKEN` as [secrets](../../user-guide/configuration/secrets) in their `screwdriver.yaml`.
@@ -505,8 +505,10 @@ In order to enable [meta PR comments](../user-guide/metadata), you’ll need to 
 
 ###### Deploy Keys
 
+Deploy Keys are repo specific SSH keys. As opposed to Personal Access Tokens. which give user-wide access for all the repositories, deploy keys, because of their limited access, are preferred for private repositories. 
+
 If users want to use deploy keys in their pipeline they have 2 options:
-* Enable automatic generation and handling of deploy keys as a part of the pipeline by using the `autoDeployKeyGeneration` flag in their `config/local.yaml`. With this flag enabled, the user will get an option to actually trigger the generation in the UI.
+* Enable automatic generation and handling of deploy keys as a part of the pipeline by setting the `autoDeployKeyGeneration` flag to `true` in their `config/local.yaml`. With this flag enabled, the user will get an option to actually trigger the generation in the UI.
 * Manually generate the public and private key pair using `openssl genrsa -out jwt.pem 2048` and `openssl rsa -in jwt.pem -pubout -out jwt.pub`. Now add the public key as a deploy key to the repo. The private key needs to be **base64 encoded** and added as a secret `SD_SCM_DEPLOY_KEY` in the pipeline. Refer [secrets](../../user-guide/configuration/secrets) for adding secrets.
 
 


### PR DESCRIPTION
## Context

screwdriver-cd/screwdriver#1079

## Objective

This PR adds instructions to the docs for adding deploy keys to the pipeline

## References

screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
