### PR TITLE
fix: add permalink pipeline jobs and artifacts to FAQ section

### DIFF
--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -39,6 +39,8 @@ toc:
       url: "#what-shell-does-screwdriver-use"
     - title: How do I speed up time to upload artifacts?
       url: "#how-do-i-speed-up-time-to-upload-artifacts"
+    - title: How do I permalink pipeline jobs and artifacts?
+      url: "#how-do-i-permalink-pipeline-jobs-and-artifacts"
     - title: How do I disable shallow cloning?
       url: "#how-do-i-disable-shallow-cloning"
     - title: What are the minimum software requirements for a build image?
@@ -51,7 +53,6 @@ toc:
       url: "#why-do-my-pull-request-builds-fail-with-the-error-fatal-refusing-to-merge-unrelated-histories-in-the-sd-setup-scm-step"
     - title: 'Why do I get "Not Found" when I try to start my pipeline?'
       url: "#why-do-i-get-not-found-when-i-try-to-start-my-pipeline"
-
 
 ---
 
@@ -167,6 +168,29 @@ By default, step commands are evaluated with the Bourne shell (`/bin/sh`). You c
 
 ## How do I speed up time to upload artifacts?
 You can set the environment variable [`SD_ZIP_ARTIFACTS`](./environment-variables#user-configurable) to `true` which will zip artifacts before uploading, provided your cluster admin has set it up properly.
+
+## How do I permalink pipeline jobs and artifacts?
+You can follow the following conventions to permalink your jobs and artifacts for your pipelines:
+
+```
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/latest?status=SUCCESS
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/latest?status=FAILURE
+/pipelines/{PIPELINE_ID}/jobs{JOB_NAME}/3
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/4?status=SUCCESS
+
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/artifacts?status=SUCCESS
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/artifacts/file-path?status=SUCCESS
+```
+
+Examples:
+
+```
+https://cd.screwdriver.cd/pipelines/1/jobs/main/latest?status=SUCCESS
+https://cd.screwdriver.cd/pipelines/1/jobs/main/6
+
+https://cd.screwdriver.cd/pipelines/1/jobs/main/artifacts?status=SUCCESS
+https://cd.screwdriver.cd/pipelines/1/jobs/main/artifacts/meta.json?status=SUCCESS
+```
 
 ## How do I disable shallow cloning?
 You can set the environment variable [`GIT_SHALLOW_CLONE`](./environment-variables#user-configurable) to `false` in order to disable shallow cloning.

--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -170,23 +170,23 @@ By default, step commands are evaluated with the Bourne shell (`/bin/sh`). You c
 You can set the environment variable [`SD_ZIP_ARTIFACTS`](./environment-variables#user-configurable) to `true` which will zip artifacts before uploading, provided your cluster admin has set it up properly.
 
 ## How do I permalink pipeline jobs and artifacts?
-You can follow the following conventions to permalink your jobs and artifacts for your pipelines:
+You can follow the following conventions to permalink your jobs and artifacts for your pipelines with given [STATUS](./configuration/settings):
 
 ```
-/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/latest?status=SUCCESS
-/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/latest?status=FAILURE
-/pipelines/{PIPELINE_ID}/jobs{JOB_NAME}/3
-/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/4?status=SUCCESS
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/latest
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/latest?status={STATUS}
 
-/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/artifacts?status=SUCCESS
-/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/artifacts/file-path?status=SUCCESS
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/artifacts?status={STATUS}
+/pipelines/{PIPELINE_ID}/jobs/{JOB_NAME}/artifacts/file-path?status={STATUS}
 ```
+
 
 Examples:
 
 ```
+https://cd.screwdriver.cd/pipelines/1/jobs/main/latest
 https://cd.screwdriver.cd/pipelines/1/jobs/main/latest?status=SUCCESS
-https://cd.screwdriver.cd/pipelines/1/jobs/main/6
+https://cd.screwdriver.cd/pipelines/1/jobs/main/latest?status=FAILURE
 
 https://cd.screwdriver.cd/pipelines/1/jobs/main/artifacts?status=SUCCESS
 https://cd.screwdriver.cd/pipelines/1/jobs/main/artifacts/meta.json?status=SUCCESS


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We have the capability to permalink jobs and artifacts of pipelines for a while, just not being documented in the guide, hence this PR.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add permalink pipeline jobs and artifacts to FAQ section

![image](https://user-images.githubusercontent.com/15989893/90569850-70e09600-e163-11ea-9f08-6a12a752b197.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Ref: https://github.com/screwdriver-cd/ui/pull/515#issuecomment-575751557
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
