### PR TITLE
fix(2185): Update to use default branch

### DIFF
--- a/docs/about/appendix/domain.md
+++ b/docs/about/appendix/domain.md
@@ -123,7 +123,7 @@ jobs:
     requires: [deploy-east]
 ```
 
-After the merge of a pull-request to master:
+After the merge of a pull-request to base branch:
 
  - `main` will run and trigger `publish`
  - `publish` will trigger `deploy-west` and `deploy-east` in parallel

--- a/docs/ja/user-guide/configuration/externalConfig.md
+++ b/docs/ja/user-guide/configuration/externalConfig.md
@@ -29,7 +29,7 @@ Screwdriverは`scmUrls`リストに基づいて子パイプラインを作成、
 childPipelines:
   scmUrls:
     - git@github.com:minz1027/test.template.git
-    - git@github.com:minz1027/quickstart-generic.git#master
+    - git@github.com:minz1027/quickstart-generic.git#main
 
 jobs:
   main:

--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -78,13 +78,13 @@ steps:
 
 You might want to skip a build if you're only changing documentation.
 
- If you don't want Screwdriver to trigger a build when you're pushing to master, add `[ci skip]` or `[skip ci]` somewhere in the commit message. If you don't want Screwdriver to trigger a build when you merge a pull request, add `[ci skip]` or `[skip ci]` to the pull request title.
+ If you don't want Screwdriver to trigger a build when you're pushing to your base branch, add `[ci skip]` or `[skip ci]` somewhere in the commit message. If you don't want Screwdriver to trigger a build when you merge a pull request, add `[ci skip]` or `[skip ci]` to the pull request title.
 
 _Note: Doesn't apply to pull request builds: a commit message containing `[skip ci]` or `[ci skip]` will still trigger a pre-commit job (a PR job will always run)._
 
 ## How do I create a pipeline?
 
-To create a pipeline, click the Create icon and paste a Git URL into the form. Followed by `#` and the branch name, if the branch is not `master`.
+To create a pipeline, click the Create icon and paste a Git URL into the form. Followed by `#` and the branch name, otherwise SCM default branch will be used.
 
 ![Create a pipeline](./assets/create-pipeline.png)
 

--- a/docs/user-guide/configuration/externalConfig.md
+++ b/docs/user-guide/configuration/externalConfig.md
@@ -26,7 +26,7 @@ In your parent repository's `screwdriver.yaml`, you can define child pipelines w
 childPipelines:
    scmUrls:
       - git@github.com:minz1027/test.template.git
-      - git@github.com:minz1027/quickstart-generic.git#master
+      - git@github.com:minz1027/quickstart-generic.git#main
 
 jobs:
     main:

--- a/docs/user-guide/configuration/workflow.md
+++ b/docs/user-guide/configuration/workflow.md
@@ -140,7 +140,7 @@ is equivalent to the Boolean expression `A OR C OR E OR (B AND D AND F)`. Such a
 Branch filtering lets you listen to events happening beyond the pipeline's specified branch. To trigger jobs in your pipeline after a commit is made on a specific branch, you can use `requires: [~commit:branchName]`. To trigger jobs in your pipeline after a pull request is made against a specific branch, you can use `requires: [~pr:branchName]`. Branches may also be specified by using a ([JavaScript flavor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)) regular expression (e.g. `~commit:/^feature-/`), although note that regex flags are not supported.
 
 ### Example
-In the following example, when a commit is made on branch `staging`, `staging-commit` and `all-commit` are triggered. Also, when a commit is made on branch `master`, `main` and `all-commit` are triggered. When a pull request is opened against branch `staging`, `staging-pr` is triggered.
+In the following example, when a commit is made on branch `staging`, both `staging-commit` job and `all-commit` job are triggered. Also, when a commit is made on branch `default`, both `main` job and `all-commit` job are triggered. When a pull request is opened against branch `staging`, `staging-pr` job is triggered.
 
 ```
 shared:

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -111,7 +111,7 @@ In order to use Screwdriver, you will need to login to Screwdriver using Github,
 
 1. _You will be asked to give Screwdriver access to your repositories. Choose appropriately and click Authorize._
 
-1. Enter your repository link into the field. SSH or HTTPS link is fine, with `#<YOUR_BRANCH_NAME>` immediately after (ex: `git@github.com:screwdriver-cd/guide.git#test`). If no `BRANCH_NAME` is provided, it will default to the `master` branch.
+1. Enter your repository link into the field. SSH or HTTPS link is fine, with `#<YOUR_BRANCH_NAME>` immediately after (ex: `git@github.com:screwdriver-cd/guide.git#test`). If no `BRANCH_NAME` is provided, it will default to the default branch configured in the SCM.
 Click Use this repository to confirm and then click Create Pipeline.
 
 ### Start Your First Build


### PR DESCRIPTION
## Context

Since we no longer hardcode to use `master` branch by default, update documentation to reflect that change.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2185

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
