### PR TITLE
fix: developing-locally

### DIFF
--- a/docs/cluster-management/developing-locally.md
+++ b/docs/cluster-management/developing-locally.md
@@ -274,8 +274,6 @@ git clone git@github.com:screwdriver-cd/queue-service.git
  ecosystem:
     # Externally routable URL for the User Interface
     ui: http://sd.screwdriver.cd:4200
-    # Externally routable URL for the API
-    api: http://$YOUR_IP:9001
     # Externally routable URL for the Artifact Store
     store: http://$YOUR_IP:9002
     # Routable URI of the queue service
@@ -283,7 +281,17 @@ git clone git@github.com:screwdriver-cd/queue-service.git
 
  executor:
     plugin: queue # <- this step is essential in order to use queue
-    queue: ''
+    queue:
+        options:
+            # Configuration of the redis instance containing resque
+            redisConnection:
+                host: "127.0.0.1"
+                port: 6379
+                options:
+                    password: 'a-secure-password'
+                    tls: false
+                database: 0
+                prefix: ""
 ```
 
 Now, you start the screwdriver backend server and queue service to use redis queue. 


### PR DESCRIPTION
## Context
When I tried as documented, I got the following error. I had to fix it to make it work correctly.

```
$ npm run start

> screwdriver-api@0.5.0 start /Users/wahapo/screwdriver
> ./bin/server

/Users/wahapo/screwdriver/bin/server:24
ecosystem.api = httpdConfig.uri;
              ^

TypeError: Cannot assign to read only property 'api' of object '#<Object>'
```

```
$ npm run start

> screwdriver-api@0.5.0 start /Users/wahapo/screwdriver
> ./bin/server

(sequelize) Warning: SQLite does not support 'INTEGER' with UNSIGNED or ZEROFILL. Plain 'INTEGER' will be used instead.
>> Check: https://www.sqlite.org/datatype3.html
Coverage plugin undefined is not supported
/Users/wahapo/screwdriver/bin/server:105
executorConfig[executorConfig.plugin].options.pipelineFactory = pipelineFactory;
                                                              ^

TypeError: Cannot set property 'pipelineFactory' of undefined
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
