### PR TITLE
fix(2198): Add docs for Sonar PR decoration

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -124,6 +124,7 @@ In order to use Sonar in your cluster, set up a Sonar server (see example at [ou
 | COVERAGE_SONAR_HOST | Yes  | Sonar host URL        |
 | COVERAGE_SONAR_ADMIN_TOKEN | Yes | Sonar admin token |
 | COVERAGE_SONAR_ENTERPRISE | No | Whether using Enterprise (true) or open source edition of SonarQube(false); default `false` |
+| COVERAGE_SONAR_GIT_APP_NAME | No | Github app name for Sonar pull request decoration; default `Screwdriver Sonar PR Checks`; This feature requires Sonar enterprise edition. Follow [instructions in the Sonar docs](https://docs.sonarqube.org/latest/analysis/pr-decoration) for details. |
 
 You’ll also need to add the `screwdriver-coverage-bookend` along with the `screwdriver-artifact-bookend` as teardown bookends by setting the `BOOKENDS_TEARDOWN` variable (in JSON format). See the Bookend Plugins section above for more details. Using Enterprise edition of SonarQube will default to _pipeline_ scope for SonarQube project keys and names. Will also allow for usage of PR analysis and prevent creation of separate projects for each Screwdriver job. Using non-Enterprise SonarQube will default to _job_ scope for SonarQube project keys and names.
 

--- a/docs/user-guide/configuration/code-coverage.md
+++ b/docs/user-guide/configuration/code-coverage.md
@@ -19,7 +19,7 @@ We currently support [SonarQube](https://github.com/screwdriver-cd/coverage-sona
 
 ## SonarQube
 
-You can configure Sonar properties in your `sonar-project.properties` file or in your screwdriver.yaml as an environment variable. The property `sonar.sources` is always required, and should be set to your source path.
+You can configure Sonar properties in your `sonar-project.properties` file or in your screwdriver.yaml as the `$SD_SONAR_OPTS` environment variable. The property `sonar.sources` is always required, and should be set to your source path.
 
 ### sonar-project.properties
 
@@ -55,7 +55,7 @@ jobs:
 ### Notes
 
 - If you define the same property in both the `sonar-project.properties` file and `$SD_SONAR_OPTS`, `$SD_SONAR_OPTS` will override the properties file.
-- Screwdriver sets the following properties for you: `sonar.host.url`, `sonar.login`, `sonar.projectKey`, `sonar.projectName`, `sonar.projectVersion`, `sonar.links.scm`, `sonar.links.ci`; you must set `sonar.sources` yourself.
+- Screwdriver sets the following properties for you: `sonar.host.url`, `sonar.login`, `sonar.projectKey`, `sonar.projectName`, `sonar.projectVersion`, `sonar.links.scm`, `sonar.links.ci`; **you must set `sonar.sources` yourself**.
 
 ### Related links
 - [SonarQube properties](https://docs.sonarqube.org/display/SONAR/Analysis+Parameters)
@@ -63,3 +63,6 @@ jobs:
 - [Javascript example](https://github.com/screwdriver-cd-test/sonar-coverage-example-javascript)
 - [Examples from the SonarQube website](https://github.com/SonarSource/sonar-scanning-examples)
 - [SonarQube docs](https://docs.sonarqube.org/display/SCAN)
+
+### Github pull request decoration
+If your Screwdriver cluster supports Sonar Enterprise, you might have the ability to add [Pull Request decoration](https://docs.sonarqube.org/7.8/analysis/pull-request/) to Checks in GitHub. If this feature is supported, you can enable it by adding the Screwdriver Sonar PR Checks Github app to your repository. Check with your Screwdriver cluster admin for support details.


### PR DESCRIPTION
## Objective

This PR adds links to Sonar PR decoration docs.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2198

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
