### PR TITLE
feat:[2] Add update command to sd-local

### DIFF
--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -40,7 +40,7 @@ $ chmod +x /usr/local/bin/sd-local
 Use the sd-local update command.
 ```bash
 $ sd-local update
-Do you want to update to 1.0.5? (y/n): y
+Do you want to update to 1.0.5? (y/N): y
 Successfully updated to version 1.0.5
 ```
 If you get the following error while running the update command,

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -40,7 +40,7 @@ $ chmod +x /usr/local/bin/sd-local
 Use the sd-local update command.
 ```bash
 $ sd-local update
-Do you want to update to 1.0.5? (y/N): y
+Do you want to update to 1.0.5? [y/N]: y
 Successfully updated to version 1.0.5
 ```
 If you get the following error while running the update command,

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -36,6 +36,23 @@ Download a latest binary of [sd-local](https://github.com/screwdriver-cd/sd-loca
 $ mv sd-local_*_amd64 /usr/local/bin/sd-local
 $ chmod +x /usr/local/bin/sd-local
 ```
+## How to Update
+Use the sd-local update command.
+```bash
+$ sd-local update
+Do you want to update to 1.0.5? (y/n): y
+Successfully updated to version 1.0.5
+```
+If you get the following error while running the update command,
+```
+Error occurred while detecting version: GET https://api.github.com/repos/screwdriver-cd/sd-local/releases: 403 API rate limit exceeded.
+```
+Please set the [GitHub personal access token.](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
+### bash
+```bash
+export GITHUB_TOKEN=<token>
+```
+
 
 # Quick start
 This section describes the steps needed to execute a build with sd-local.  

--- a/docs/user-guide/local.md
+++ b/docs/user-guide/local.md
@@ -40,8 +40,8 @@ $ chmod +x /usr/local/bin/sd-local
 Use the sd-local update command.
 ```bash
 $ sd-local update
-Do you want to update to 1.0.5? [y/N]: y
-Successfully updated to version 1.0.5
+Do you want to update to 1.0.x? [y/N]: y
+Successfully updated to version 1.0.x
 ```
 If you get the following error while running the update command,
 ```


### PR DESCRIPTION
## Context

Update sd-local with the following documentation each time.
https://docs.screwdriver.cd/user-guide/local.html#installing-sd-local
Users cannot easily use the updated sd-local.
Therefore, sd-local will run the update command so that you can update to the latest version.

## Objective
Add so that sd-local users can use the update command.

## References
[1] sd-local https://github.com/screwdriver-cd/sd-local/pull/42
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
