### PR TITLE
clarify ability to use alias in image: line

### DIFF
--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -152,7 +152,7 @@ images:
     stable-image: node:6
     latest-image: node:8
 config:
-    image: node:6
+    image: stable-image
     steps:
         - install: npm install
         - test: npm test


### PR DESCRIPTION
The example of using 'images' doesn't use one of the aliases  for the
default image in the provided config. If I didn't know of
templates that do use the alias in that way, I might have thought
that I needed to use the unaliased image in the config section.


## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
