### PR TITLE
feat: add docs for teardown steps

### DIFF
--- a/docs/user-guide/configuration/annotations.md
+++ b/docs/user-guide/configuration/annotations.md
@@ -56,7 +56,7 @@ The following annotations are supported by plugins maintained by Screwdriver.cd.
 | screwdriver.cd/coverageScope | `pipeline` / `job` | When using the coverage plugin, this will set the scope for project creation. Default behavior depends on cluster configuration (e.g. `COVERAGE_SONAR_ENTERPRISE`), please check with your cluster admin for that. |
 | screwdriver.cd/displayName | Job name to display in the pipeline graph | You can use any name you like for a job to appear in the pipeline graph, without being limited by the unique constraints of Yaml. |
 | screwdriver.cd/mergeSharedSteps | `true` / `false` | When using a template, set it to `true`, and allow the user to merge steps defined in shared and job. Default is `false`. |
-
+| screwdriver.cd/terminationGracePeriodSeconds | Number of seconds | This will allow the user to choose the number of seconds a build should wait before aborting to execute the teardown steps. Default is `'60'` minutes and Max is `'120'`. In most cases more than default will not be required. |
 ## Pipeline-Level Annotations
 
 Pipeline-level annotations are used to modify the properties of the entire pipeline. Pipeline-level annotations are under the same level as `shared` and `jobs`. Pull requests cannot change these annotations, they need to be in the SCM branch of the pipeline.

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -76,7 +76,7 @@ jobs:
 ```
 
 ## Teardown
-The teardown steps run a set of screwdriver bookend steps after the build steps are completed or aborted or failed. These steps are implicity added at the end of job and start with "sd-teardown-". The pod/container is removed after these steps are completed. In case of aborted builds, we can also configure the grace period of the pod before termination during which the teardown steps will be executed. See [annotations](/user-guide/configuration/annotations) for detailed usage
+The teardown steps run a set of Screwdriver bookend steps after the build steps are completed or aborted or failed. These steps are implicitly added at the end of job and start with "sd-teardown-". The pod/container is removed after these steps are completed. In case of aborted builds, we can also configure the grace period of the pod before termination during which the teardown steps will be executed. See [annotations](/user-guide/configuration/annotations) for detailed usage.
 
 # Shared
 The `shared` configuration is a special job configuration section that is applied to all jobs. Configuration that is specified in a job configuration will override the same configuration in `shared`.

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -10,6 +10,8 @@ toc:
       url: "#image"
     - title: Steps
       url: "#steps"
+    - title: Teardown
+      url: "#teardown"
     - title: Shared Configuration
       url: "#shared"
 ---

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -75,6 +75,8 @@ jobs:
             - teardown-mystep2: echo world
 ```
 
+## Teardown
+The teardown steps run a set of screwdriver bookend steps after the build steps are completed or aborted or failed. These steps are implicity added at the end of job and start with "sd-teardown-". The pod/container is removed after these steps are completed. In case of aborted builds, we can also configure the grace period of the pod before termination during which the teardown steps will be executed. See [annotations](/user-guide/configuration/annotations) for detailed usage
 
 # Shared
 The `shared` configuration is a special job configuration section that is applied to all jobs. Configuration that is specified in a job configuration will override the same configuration in `shared`.


### PR DESCRIPTION
## Context

Screwdriver now runs teardown steps when a build is aborted and thus saves all the artifacts created till the last step that ran.

## Objective

This PR adds the documentation for the teardown steps and annotation configuration

## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
