### PR TITLE
Update README to include instructions for running jekyll with docker rather than installing it.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,11 +59,10 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux-musl
 
 DEPENDENCIES
   jekyll (= 4.0.0)
   tzinfo-data
 
 BUNDLED WITH
-   2.2.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,10 +59,11 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux-musl
 
 DEPENDENCIES
   jekyll (= 4.0.0)
   tzinfo-data
 
 BUNDLED WITH
-   2.1.4
+   2.2.2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,20 @@ For more information about Screwdriver, check out our [homepage](http://screwdri
 Have a look at our guidelines, as well as pointers on where to start making changes, in our [contributing guide](http://docs.screwdriver.cd/about/contributing).
 
 
-The guide is powered by Jekyll. In order to install Jekyll you'll need Ruby, the Ruby package manager (RubyGems), and bundle to install and run Jekyll. You can check if you have these already installed like so:
+The guide is powered by Jekyll. There are two ways to run jekyll, via docker and by installing.
+
+### Running jekyll using docker
+
+1. Install [docker-desktop](https://www.docker.com/products/docker-desktop) if you haven't already.
+1. Ensure docker is running - `docker info` should give you info; if not, then on mac, you can launch easily via `open -a /Applications/Docker.app/` - launching on CLI (rather than double-clicking) has advantage of exporting your `$SSH_AUTH_SOCK` and `ssh-agent` will work properly, should you need it at some point. 
+1. Run the jekyll docker image with mount of `$PWD` to its serving location and with `-ti` so `^C` will kill it.
+   ```bash
+   docker run -v $PWD:/srv/jekyll:rw -p 4080:4000 -it jekyll/jekyll jekyll serve --source docs --destination _site
+   ```
+
+### Running jekyll by installing
+
+In order to install Jekyll you'll need Ruby, the Ruby package manager (RubyGems), and bundle to install and run Jekyll. You can check if you have these already installed like so:
 
 ```bash
 $ ruby --version

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ For more information about Screwdriver, check out our [homepage](http://screwdri
 Have a look at our guidelines, as well as pointers on where to start making changes, in our [contributing guide](http://docs.screwdriver.cd/about/contributing).
 
 
-The guide is powered by Jekyll. There are two ways to run jekyll, via docker and by installing.
+The guide is powered by Jekyll. There are two ways to run Jekyll: via Docker and via installation.
 
-### Running jekyll using docker
+### Running Jekyll using Docker
 
 1. Install [docker-desktop](https://www.docker.com/products/docker-desktop) if you haven't already.
-1. Ensure docker is running - `docker info` should give you info; if not, then on mac, you can launch easily via `open -a /Applications/Docker.app/` - launching on CLI (rather than double-clicking) has advantage of exporting your `$SSH_AUTH_SOCK` and `ssh-agent` will work properly, should you need it at some point. 
-1. Run the jekyll docker image with mount of `$PWD` to its serving location and with `-ti` so `^C` will kill it.
+1. Ensure Docker is running with `docker info`; if not, then on Mac, you can launch easily using `open -a /Applications/Docker.app/`. Launching on CLI (rather than double-clicking) has advantage of exporting your `$SSH_AUTH_SOCK` and `ssh-agent` will work properly, should you need it at some point. 
+1. Run the Jekyll Docker image with mount of `$PWD` to its serving location and with `-ti` so `^C` will kill it.
    ```bash
    docker run -v $PWD:/srv/jekyll:rw -p 4080:4000 -it jekyll/jekyll jekyll serve --source docs --destination _site
    ```
 
-### Running jekyll by installing
+### Running Jekyll by installing
 
 In order to install Jekyll you'll need Ruby, the Ruby package manager (RubyGems), and bundle to install and run Jekyll. You can check if you have these already installed like so:
 


### PR DESCRIPTION
## Context

Installing ruby and jekyll hit version conflicts on my mac; running in docker is both possible and avoids conflicts with what's on the host system.

## Objective

Run jekyll with docker, mounting `$PWD` into its serving location so it can see your local files.

## References

* <https://alcher.dev/2020/jekyll-on-docker/>

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
