### PR TITLE
feat(2319): Add template order docs

### DIFF
--- a/docs/user-guide/configuration/index.md
+++ b/docs/user-guide/configuration/index.md
@@ -44,11 +44,13 @@ You can access information about properties by hovering over the property name.
         <a href="#steps"><span class="key">steps</span>:
     - <span class="key">init</span>: <span class="value">npm install</span>
     - <span class="key">test</span>: <span class="value">npm test</span></a>
-    <a href="#jobs"><span class="key">publish</span>:
-    <span class="key">requires</span>: <span class="value">main</span>
-    <span class="key">image</span>: <span class="value">node:6</span>
-    <span class="key">steps</span>:
-        - <span class="key">publish</span>: <span class="value">npm publish</span></a>
+    <span class="key">publish</span>:
+      <a href="#requires"><span class="key">requires</span>: <span class="value">[main]</span></a>
+      <a href="#template"><span class="key">template</span>: <span class="value">node/publish@4.3.1</span></a>
+      <a href="#order"><span class="key">order</span>: <span class="value">[init, publish, teardown-save-results]</span></a>
+      <span class="key">steps</span>:
+  - <span class="key">publish</span>: <span class="value">npm install</span>
+  - <a href="#teardown"><span class="key">teardown-save-results</span>: <span class="value">cp ./results $SD_ARTIFACTS_DIR</span></a>
     <a href="#jobs"><span class="key">deploy-west</span>:
     <span class="key">requires</span>: <span class="value">publish</span>
     <span class="key">image</span>: <span class="value">node:6</span>
@@ -111,7 +113,7 @@ You can access information about properties by hovering over the property name.
         </div>
         <div id="email" class="hidden">
             <h4>Email</h4>
-            <p>Emails addresses to send notifications to and statuses to send notifications for.</p>
+            <p>Email addresses to send notifications to and statuses to send notifications for.</p>
         </div>
         <div id="parameters" class="hidden">
             <h4>Parameters</h4>
@@ -128,6 +130,18 @@ You can access information about properties by hovering over the property name.
         <div id="steps" class="hidden">
             <h4>Steps</h4>
             <p>Defines the explicit list of commands that are executed in the build, just as if they were entered on the command line. Environment variables will be passed between steps, within the same job. Step definitions are required for all jobs. Step names cannot start with `sd-`, as those steps are reserved for Screwdriver steps. In essence, Screwdriver runs `/bin/sh` in your terminal then executes all the steps; in rare cases, different terminal/shell setups may have unexpected behavior.</p>
+        </div>
+        <div id="template" class="hidden">
+            <h4>Template</h4>
+            <p>A predefined job; generally consists of a Docker image and steps.</p>
+        </div>
+        <div id="order" class="hidden">
+            <h4>Order</h4>
+            <p>Can only be used when "template" is defined. Step names that should be run in a particular order. Will select steps from Template and Steps, with priority given to Steps defined in the job.</p>
+        </div>
+        <div id="teardown" class="hidden">
+            <h4>Teardown</h4>
+            <p>User-defined steps that will always run at the end of a build (even if the previous steps fail or the build is aborted). Step name always starts with "teardown-".</p>
         </div>
     </div>
 </div>

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -14,7 +14,10 @@ toc:
       url: "#teardown"
       subitem: 1
     - title: Shared Configuration
-      url: "#shared"
+      url: "#shared-configuration"
+    - title: Merge shared steps
+      url: "#merge-shared-steps"
+      subitem: 1
 ---
 # Job Configuration
 Jobs are how you define what happens in every build. Every job configuration must consist of an `image` and a list of `steps`, or a `template`. It also defines trigger requirement for the job using `requires`. See [workflow](/user-guide/configuration/workflow) for detailed usage of `requires` to create pipeline workflow.
@@ -50,7 +53,7 @@ jobs:
 Steps are the list of instructions you want to execute in your build. These should be defined as:
 `step_name: step_command`. Steps will be executed in the order they are defined. Current working directory and environment variables are passed between steps.
 
-You can also specify user teardown steps, which will be run regardless of whether the build succeeds or fails. These steps need to be at the end of the job and start with "teardown-".
+You can also specify user teardown steps, which will be run regardless of whether the build succeeds or fails. These steps need to be at the end of the job and should be prefixed with `teardown-`.
 
 Example repo: <https://github.com/screwdriver-cd-test/user-teardown-example>
 
@@ -81,7 +84,7 @@ jobs:
 ### Teardown
 The teardown steps run a set of Screwdriver bookend steps after the build steps are completed or aborted or failed. These steps are implicitly added at the end of job and start with `sd-teardown-` or `teardown-`. The pod/container is removed after these steps are completed. In case of aborted builds, we can also configure the grace period of the pod before termination during which the teardown steps will be executed. See the `screwdriver.cd/terminationGracePeriodSeconds` [annotation](/user-guide/configuration/annotations) for detailed usage.
 
-# Shared
+# Shared Configuration
 The `shared` configuration is a special job configuration section that is applied to all jobs. Configuration that is specified in a job configuration will override the same configuration in `shared`.
 
 #### Example
@@ -91,6 +94,7 @@ shared:
     image: node:8
     steps:
         - init: npm install
+        - pretest: npm lint
         - test: npm test
 
 jobs:
@@ -100,7 +104,7 @@ jobs:
     main2:
         requires: [main]
         steps:
-            - greet: echo hello
+            - test: echo Skipping test
 ```
 
 The above example would be equivalent to:
@@ -111,14 +115,62 @@ jobs:
         image: node:6
         steps:
             - init: npm install
+            - pretest: npm lint
             - test: npm test
     main2:
         requires: [main]
         image: node:8
         steps:
-            - greet: echo hello
+            - test: echo Skipping test
 
 ```
+
+## Merge shared steps
+You can choose to merge shared steps with the [annotation](./annotations) `screwdriver.cd/mergeSharedSteps: true`.
+
+#### Example
+The following example defines a merged shared configuration for `image` and `steps`, which is used by the main and main2 jobs.
+```
+shared:
+    image: node:8
+    steps:
+        - init: npm install
+        - pretest: npm lint
+        - test: npm test
+
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        image: node:6
+    main2:
+        annotations:
+            screwdriver.cd/mergeSharedSteps: true
+        requires: [main]
+        steps:
+            - test: echo Skipping test
+```
+
+The above example would be equivalent to:
+```
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        image: node:6
+        steps:
+             - init: npm install
+             - pretest: npm lint
+             - test: npm test
+    main2:
+        annotations:
+             screwdriver.cd/mergeSharedSteps: true
+        requires: [main]
+        image: node:8
+        steps:
+             - pretest: npm lint
+             - test: echo Skipping test
+
+```
+
 
 ### See also:
 * [Annotations](/user-guide/configuration/annotations) - Freeform key/value store, often used to configure build execution settings

--- a/docs/user-guide/configuration/jobconfiguration.md
+++ b/docs/user-guide/configuration/jobconfiguration.md
@@ -15,8 +15,6 @@ toc:
       subitem: 1
     - title: Shared Configuration
       url: "#shared-configuration"
-    - title: Merge shared steps
-      url: "#merge-shared-steps"
       subitem: 1
 ---
 # Job Configuration
@@ -122,52 +120,6 @@ jobs:
         image: node:8
         steps:
             - test: echo Skipping test
-
-```
-
-## Merge shared steps
-You can choose to merge shared steps with the [annotation](./annotations) `screwdriver.cd/mergeSharedSteps: true`.
-
-#### Example
-The following example defines a merged shared configuration for `image` and `steps`, which is used by the main and main2 jobs.
-```
-shared:
-    image: node:8
-    steps:
-        - init: npm install
-        - pretest: npm lint
-        - test: npm test
-
-jobs:
-    main:
-        requires: [~pr, ~commit]
-        image: node:6
-    main2:
-        annotations:
-            screwdriver.cd/mergeSharedSteps: true
-        requires: [main]
-        steps:
-            - test: echo Skipping test
-```
-
-The above example would be equivalent to:
-```
-jobs:
-    main:
-        requires: [~pr, ~commit]
-        image: node:6
-        steps:
-             - init: npm install
-             - pretest: npm lint
-             - test: npm test
-    main2:
-        annotations:
-             screwdriver.cd/mergeSharedSteps: true
-        requires: [main]
-        image: node:8
-        steps:
-             - pretest: npm lint
-             - test: echo Skipping test
 
 ```
 

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -10,6 +10,8 @@ toc:
       url: "#finding-templates"
     - title: Using a template
       url: "#using-a-template"
+    - title: "Version/Tag Semantics"
+      url: "#versiontag-semantics"
     - title: Overriding Template Steps
       url: "#overriding-template-steps"
       subitem: true
@@ -22,6 +24,9 @@ toc:
     - title: Merging with Shared Steps
       url: "#merging-with-shared-steps"
       subitem: level-2
+    - title: Step order
+      url: "#step-order"
+      subitem: true
     - title: Creating a template
       url: "#creating-a-template"
     - title: Testing a template
@@ -75,7 +80,7 @@ Template versions can be referenced in a variety of ways that express users' tra
 * `nodejs/test@1.0` - this will use the most recent version of `nodejs/test` than is less than 1.1.0. This is essentially the `latest` tag without crossing a minor version boundary.
 * `nodejs/test@1.0.4` - this is the most predictable way to specify a pipeline's behavior and is not affected by future changes to the template.
 
-## Example
+#### Example
 
 For this configuration:
 ```yaml
@@ -168,6 +173,63 @@ jobs:
 
 ```
 
+### Step order
+When using a template in your `screwdriver.yaml`, you can pick and choose steps defined by the template and your own configuration with the `order` field. You can also use a template in an `sd-template.yaml`. Defined as an ordered array of step names.
+
+Caveats:
+- `order` can only be used when `template` is used.
+- Steps that cannot be found will be skipped.
+- User-defined `teardown-` steps will always be run after the rest of the steps are done.
+- Implicit wrapping of steps(pre/post) will not work with this field.
+- The priority in determining duplicate step definitions goes like this: job > template
+- When the annotation `screwdriver.cd/mergeSharedSteps: true`, priority will be: job > shared > template
+- If you use a `template` in an `sd-template.yaml`, the `images` field will also be merged.
+
+Example `sd-template.yaml`:
+```yaml
+namespace: nodejs
+name: publish
+version: "2.0.1"
+description: 'Publish an npm package'
+maintainer: myname@foo.com
+images:
+  stable: node:8
+  latest: node:12
+config:
+  image: stable
+  steps:
+    - install: npm install
+    - publish: npm publish
+    - coverage: coverage test.js
+```
+
+Example `screwdriver.yaml`:
+```yaml
+jobs:
+  main:
+    requires: [~commit]
+    image: stable
+    template: nodejs/publish@2
+    order: [clone, install, doesnotexist, test, publish, coverage]
+    steps:
+      - test: npm test
+      - clone: git clone https://github.com/screwdriver-cd/toolbox.git ci
+      - coverage: ./ci/coverage.sh
+```
+
+Result:
+```yaml
+jobs:
+  main:
+    requires: [~commit]
+    image: node:8
+    steps:
+      - clone: git clone https://github.com/screwdriver-cd/toolbox.git ci
+      - install: npm install
+      - test: npm test
+      - publish: npm publish
+      - coverage: ./ci/coverage.sh  # This step was overwritten by the job
+```
 
 ## Creating a template
 
@@ -248,9 +310,13 @@ It becomes unclear whether the user was trying to override `preinstall` or wrap 
 
 ### Writing a screwdriver.yaml for your template repo
 
+#### Validating templates
+
 To validate your template, run the `template-validate` script from the `screwdriver-template-main` npm module in your `main` job to validate your template. This means the build image must have NodeJS and NPM properly installed to use it. To publish your template, run the `template-publish` script from the same module in a separate job.
 
 By default, the file at `./sd-template.yaml` will be read. However, a user can specify a custom path using the env variable: `SD_TEMPLATE_PATH`.
+
+You can also validate your `sd-template.yaml` and `screwdriver.yaml` through the UI by copy pasting it at `<YOUR_UI_URL>/validator`.
 
 #### Tagging templates
 You can optionally tag a specific template version by running the `template-tag` script from the `screwdriver-template-main` npm package. This must be done by the same pipeline that your template is created by. You will need to provide arguments to the script: template name and tag. You can optionally specify a version; the version needs to be an exact version (see `tag` step). If the version is omitted, the most recent version will be tagged (see `autotag` step).

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -24,9 +24,12 @@ toc:
     - title: Merging with Shared Steps
       url: "#merging-with-shared-steps"
       subitem: level-2
-    - title: Step order
-      url: "#step-order"
+    - title: Template Composition
+      url: "#template-composition"
       subitem: true
+    - title: Step Order
+      url: "#step-order"
+      subitem: level-2
     - title: Creating a template
       url: "#creating-a-template"
     - title: Testing a template
@@ -157,7 +160,8 @@ jobs:
 When overriding Template steps, a job can get the step definitions from either `shared.steps` or `job.steps` with precedence for `steps` defined in `job` section. This follows the same order of precedence for step definitions without using a template. Users can change this behavior using [annotation](./configuration/annotations) `screwdriver.cd/mergeSharedSteps: true`. When `true` steps in `shared` and `job` sections are merged when a Template is used.
 
 
-Example
+#### Example
+
 ```yaml
 shared:
   annotations:
@@ -173,8 +177,56 @@ jobs:
 
 ```
 
+#### Example
+The following example defines a merged shared configuration for `image` and `steps`, which is used by the main and main2 jobs.
+
+```yaml
+shared:
+    image: node:8
+    steps:
+        - init: npm install
+        - pretest: npm lint
+        - test: npm test
+
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        image: node:6
+    main2:
+        annotations:
+            screwdriver.cd/mergeSharedSteps: true
+        requires: [main]
+        steps:
+            - test: echo Skipping test
+```
+
+The above example would be equivalent to:
+
+```yaml
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        image: node:6
+        steps:
+             - init: npm install
+             - pretest: npm lint
+             - test: npm test
+    main2:
+        annotations:
+             screwdriver.cd/mergeSharedSteps: true
+        requires: [main]
+        image: node:8
+        steps:
+             - pretest: npm lint
+             - test: echo Skipping test
+
+```
+
+## Template Composition
+You can use a template in a template (`sd-template.yaml`) or in your normal configuration file (`screwdriver.yaml`).
+
 ### Step order
-When using a template in your `screwdriver.yaml`, you can pick and choose steps defined by the template and your own configuration with the `order` field. You can also use a template in an `sd-template.yaml`. Defined as an ordered array of step names.
+When using a template in your configuration, you can pick and choose steps defined by the template and your own configuration with the `order` field. This field is defined as an ordered array of step names.
 
 Caveats:
 - `order` can only be used when `template` is used.


### PR DESCRIPTION
## Context

Users can now use templates in templates. They can also use the new field `order` to pick and choose steps from a template and their own job configs.

## Objective

This PR adds docs for the new feature.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
