### PR TITLE
fix: add instructions to use local launcher image

### DIFF
--- a/docs/cluster-management/developing-locally.md
+++ b/docs/cluster-management/developing-locally.md
@@ -322,3 +322,30 @@ Now, you start the screwdriver backend server and queue service to use redis que
 ```bash
 npm install && npm run start
 ```
+
+## Developing locally with a custom launcher image
+
+### Build your own launcher binary and image
+```bash
+git clone git@github.com:screwdriver-cd/launcher.git
+cd launcher
+env GOOS=linux GOARCH=arm go build .
+docker build . -f Dockerfile.local
+# let x be the IMAGE ID. You need to be signed in to your Docker account in Docker app
+docker tag X jithine/launcher:dev
+docker push jithine/launcher:dev
+
+```
+
+### Modify API locl.yaml to use your local launcher
+```yaml
+ executor:
+    plugin: docker
+    docker:
+      enabled: true
+      options:
+        launchImage: jithine/launcher
+        launchVersion: dev
+        docker:
+            socketPath: "/var/run/docker.sock"
+```

--- a/docs/cluster-management/developing-locally.md
+++ b/docs/cluster-management/developing-locally.md
@@ -9,6 +9,8 @@ toc:
       active: true
     - title: Developing locally with executor-queue
       url: "#developing-locally-with-executor-queue-and-queue-service"
+    - title: Developing locally with custom launcher
+      url: "#developing-locally-with-a-custom-launcher-image
 
 ---
 ## Developing Locally


### PR DESCRIPTION
## Context

Improve local development experience 

## Objective

Followup to https://github.com/screwdriver-cd/executor-docker/pull/41

## References

https://github.com/screwdriver-cd/screwdriver/issues/2356

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
