### PR TITLE
fix: upd build cache documentation

### DIFF
--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -99,8 +99,8 @@ jobs:
 ## Update Cache from parallel jobs
 
 Please be cautious when specifying same cache path at an event or pipeline level in screwdriver.yaml having parallel jobs. 
-When jobs run in parallel there is no guarantee which job will succeed first in writing cache, therefore the 
-same cache folder might get overwritten or lost.
+When jobs run in parallel there is no guarantee which job will succeed first in writing cache, therefore the same cache path 
+might get overwritten or lost.
 
 How to handle above scenario? 
 1. Use the store-cli set command explicitly in a job where you need to cache.

--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -98,7 +98,7 @@ jobs:
 
 ## Update Cache from parallel jobs
 
-Please be cautious when specifying same event or pipeline level cache path in screwdriver.yaml having parallel jobs. 
+Please be cautious when specifying same cache path at an event or pipeline level in screwdriver.yaml having parallel jobs. 
 When jobs run in parallel there is no guarantee which job will succeed first in writing cache, therefore the 
 same cache folder might get overwritten or lost.
 

--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -105,7 +105,7 @@ same cache folder might get overwritten or lost.
 How to handle above scenario? 
 1. Use the store-cli set command explicitly in a job where you need to cache.
 2. Specify different cache folders from each job that you want to cache and use them accordingly. 
-3. Do write a cache from single job and then run jobs in parallel. 
+3. Do write cache from single job and then run jobs in parallel. 
 
 ## Clearing the Cache
 In order to clear the cache, you can go to the Options tab for your pipeline in the Screwdriver UI and click on the Trash icon under the Cache section.

--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -12,6 +12,8 @@ toc:
       url: "#notes"
     - title: Disable Cache for a Specific Job
       url: "#disable-cache-for-a-specific-job"
+    - title: Update Cache from Parallel jobs
+      url: "#update-cache-from-paralel-jobs"
     - title: Clearing the Cache
       url: "#clearing-the-cache"
 ---
@@ -96,13 +98,13 @@ jobs:
         cache: false
 ```
 
-## Update Cache from parallel jobs
+## Update Cache from Parallel jobs
 
 Please be cautious when specifying same cache path at an event or pipeline level in screwdriver.yaml having parallel jobs. 
 When jobs run in parallel there is no guarantee which job will succeed first in writing cache, therefore the same cache path 
 might get overwritten or lost.
 
-How to handle above scenario? 
+How to handle the above scenario? 
 1. Use the store-cli set command explicitly in a job where you need to cache.
 2. Specify different cache folders from each job that you want to cache and use them accordingly. 
 3. Do write cache from single job and then run jobs in parallel. 

--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -96,6 +96,17 @@ jobs:
         cache: false
 ```
 
+## Update Cache from parallel jobs
+
+Please be cautious when specifying same event or pipeline level cache path in screwdriver.yaml having parallel jobs. 
+When jobs run in parallel there is no guarantee which job will succeed first in writing cache, therefore the 
+same cache folder might get overwritten or lost.
+
+How to handle above scenario? 
+1. Use the store-cli set command explicitly in a job where you need to cache.
+2. Specify different cache folders from each job that you want to cache and use them accordingly. 
+3. Do write a cache from single job and then run jobs in parallel. 
+
 ## Clearing the Cache
 In order to clear the cache, you can go to the Options tab for your pipeline in the Screwdriver UI and click on the Trash icon under the Cache section.
 

--- a/docs/user-guide/configuration/build-cache.md
+++ b/docs/user-guide/configuration/build-cache.md
@@ -102,7 +102,7 @@ Please be cautious when specifying same cache path at an event or pipeline level
 When jobs run in parallel there is no guarantee which job will succeed first in writing cache, therefore the same cache path 
 might get overwritten or lost.
 
-How to handle above scenario? 
+How to handle the above scenario? 
 1. Use the store-cli set command explicitly in a job where you need to cache.
 2. Specify different cache folders from each job that you want to cache and use them accordingly. 
 3. Do write cache from single job and then run jobs in parallel. 


### PR DESCRIPTION
## Context
## Objective

Add build-cache documentation on how to handle cache updates from parallel jobs

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
