### PR TITLE
docs: fix Japanese translation 202102~03

### DIFF
--- a/docs/_data/menu_ja.yml
+++ b/docs/_data/menu_ja.yml
@@ -64,8 +64,6 @@
       url: "/ja/cluster-management/configure-queue-service"
     - title: ビルドクラスターキューワーカーの設定
       url: "/ja/cluster-management/configure-buildcluster-queue-worker"
-    - title: "ローカルで開発"
-      url: "/ja/cluster-management/developing-locally"
     - title: "SD-in-a-Box"
       url: "/ja/cluster-management/running-locally"
     - title: "Kubernetesを利用してAWS上にScrewdriverのクラスタを構築"


### PR DESCRIPTION
## Context

I translated it in the following [PR](https://github.com/screwdriver-cd/guide/pull/462), but forgot to correct one point.

[here](https://github.com/screwdriver-cd/guide/compare/v0.0.337...v0.0.349#diff-73a2d7f8f1152c5386f94a368f67272cc2095e327f91ba0af7fd6acfaf709310)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
