### PR TITLE
fix: Update community docs

### DIFF
--- a/docs/about/announcements.md
+++ b/docs/about/announcements.md
@@ -11,8 +11,8 @@ toc:
       url: "#blog"
     - title: Twitter
       url: "#twitter"
-    - title: Meeting
-      url: "#meeting"
+    - title: Community
+      url: "#community"
 ---
 # Announcements
 
@@ -22,27 +22,5 @@ When new features are rolled out, we write about them in our blog. You can also 
 ## Twitter
 We use Twitter for meetup and conference updates and blog updates. Follow us at [twitter.com/screwdrivercd](https://twitter.com/screwdrivercd).
 
-## Meeting
-
-We have public bi-weekly meeting on Mondays at 6PM PT.
-
-Where: [Google Meet](https://meet.google.com/rwo-ynwh-xqy?hs=122)
-       `Phone +1 601-844-2661 PIN: 449 924#`
-
-When:  Starting Monday, October 7 2019 between 6 - 6:30 PM PT. Repeats every 2 weeks.
-
-
-### Purpose
-
-This meeting is for Screwdriver cluster administrators and developers to share operational knowledge, product feature requirements and challenges.
-
-### Agenda
-
-1. Introduction by attendees.
-1. Developers to provide update on work in progress.
-1. Cluster admins to share operational knowledge and issues or feature requests from their users.
-1. Discuss
-
-### Archives
-
-Meetings notes to be archived at TBD.
+## Community
+Check out Screwdriver community meeting times, notes, and other public documents in our [community repo](https://github.com/screwdriver-cd/community).


### PR DESCRIPTION
## Context

Would be nice if we could keep community meeting information in one place.

## Objective

This PR points the community section to the community repo so we only need to update the information in one place.

## References

N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
