### PR TITLE
fix: Support pending status check for GitHub PRs [2]

### DIFF
--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -171,8 +171,8 @@ The fields you can set:
 
 | Key | Default | Description |
 | --- | ------- | ----------- |
-| status (String) | `SUCCESS` | Status of the check, can be one of `SUCCESS`, `FAILURE`, `PENDING` |
-| message (String) | `fieldName check succeeded` | Description for the check |
+| status (String) | `PENDING` | Status of the check, can be one of `SUCCESS`, `FAILURE`, `PENDING` |
+| message (String) | `fieldName check pending` | Description for the check |
 | url (String) | build link | URL for the check to link to |
 
 For example, to add two additional checks for `findbugs` and `coverage`, your screwdriver.yaml should look something like below:

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -169,11 +169,11 @@ To additional checks to a pull request, you just need to set `meta.status.<check
 
 The fields you can set:
 
-| Key | Description |
-| --- | ----------- |
-| status (String) | Status of the check, can be one of: (`SUCCESS`, `FAILURE`) |
-| message (String) | Description for the check |
-| url (String) | Url for the check to link to (default: build link)
+| Key | Default | Description |
+| --- | ------- | ----------- |
+| status (String) | `SUCCESS` | Status of the check, can be one of `SUCCESS`, `FAILURE`, `PENDING` |
+| message (String) | `fieldName check succeeded` | Description for the check |
+| url (String) | build link | URL for the check to link to |
 
 For example, to add two additional checks for `findbugs` and `coverage`, your screwdriver.yaml should look something like below:
 


### PR DESCRIPTION
## Objective

Update docs to new PENDING status check for GitHub PRs.

## References

Related to https://github.com/screwdriver-cd/models/pull/496

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
