### PR TITLE
Badge clean up

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -208,13 +208,12 @@ httpd:
 
 ### Ecosystem
 
-Specify externally routable URLs for your UI, Artifact Store, and Badge service.
+Specify externally routable URLs for your UI and Artifact Store service.
 
 | Key              | Default                                                     | Description                                  |
 |:-----------------|:------------------------------------------------------------|:---------------------------------------------|
 | ECOSYSTEM_UI     | https://cd.screwdriver.cd                                   | URL for the User Interface                   |
 | ECOSYSTEM_STORE  | https://store.screwdriver.cd                                | URL for the Artifact Store                   |
-| ECOSYSTEM_BADGES | https://img.shields.io/badge/build-{{status}}-{{color}}.svg | URL with templates for status text and color |
 | ECOSYSTEM_QUEUE  | http://sdqueuesvc.screwdriver.svc.cluster.local             | Internal URL for the Queue Service to be used with queue plugin |
 
 ```yaml
@@ -224,8 +223,6 @@ ecosystem:
     ui: https://cd.screwdriver.cd
     # Externally routable URL for the Artifact Store
     store: https://store.screwdriver.cd
-    # Badge service (needs to add a status and color)
-    badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg
     # Internally routable FQDNS of the queue svc
     queue: http://sdqueuesvc.screwdriver.svc.cluster.local
 ```


### PR DESCRIPTION
## Context

Clean up of badges API changes

## Objective

Badges are no longer needed for configuration

## References

https://github.com/screwdriver-cd/screwdriver/issues/2418
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
