### PR TITLE
fix(1890): Remove caveat for sourceDir, should be available in all SCMs

### DIFF
--- a/docs/user-guide/configuration/sourceDirectory.md
+++ b/docs/user-guide/configuration/sourceDirectory.md
@@ -44,8 +44,7 @@ In this example, jobs that `requires: [~commit, ~pr]` will be triggered if there
 Example repo: <https://github.com/screwdriver-cd-test/source-dir-example>
 
 ### Caveats
-- This feature is only available for the [Github SCM](https://github.com/screwdriver-cd/scm-github) right now.
-- If you use `sourcePaths` together with custom source directory, the scope of the `sourcePaths` is limited to your source directory. You can not listen on changes that are outside your source directory. ***Note*** the path for your `sourcePaths` is relative to the root of the repository not your source directory.
+- If you use [sourcePaths](../sourcePaths) together with custom source directory, the scope of the `sourcePaths` is limited to your source directory. You can not listen on changes that are outside your source directory. ***Note*** the path for your `sourcePaths` is relative to the root of the repository, not your source directory.
 
   - For example, if you want to add sourcePaths to listen on changes to `main.js` and `screwdriver.yaml`, you should set:
 ```


### PR DESCRIPTION
## Context

SourceDir feature should be available in all SCMs now: https://docs.screwdriver.cd/user-guide/scm

## Objective

This PR removes caveat on Source Dir page.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1890

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
