### PR TITLE
add step to run htmlproof

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,5 @@ gem "jekyll", "4.0.0"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'html-proofer', '~> 3.19', '>= 3.19.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,19 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.13.1)
     forwardable-extended (2.6.0)
+    html-proofer (3.19.2)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -42,9 +52,18 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    nokogiri (1.11.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
+    nokogumbo (2.0.5)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.20.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.5)
+    racc (1.5.2)
+    rainbow (3.0.0)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -55,14 +74,19 @@ GEM
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     unicode-display_width (1.7.0)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
+  x86_64-darwin-20
   x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES
+  html-proofer (~> 3.19, >= 3.19.2)
   jekyll (= 4.0.0)
   tzinfo-data
 

--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -580,9 +580,9 @@ scms:
             autoDeployKeyGeneration: false # [Optional] Set to true to allow automatic generation of private and public deploy keys and add them to the build pipeline and Github for repo checkout, respectively
 ```
 
-If users want to use private repo, they also need to set up `SCM_USERNAME` and `SCM_ACCESS_TOKEN` as [secrets](../../user-guide/configuration/secrets) in their `screwdriver.yaml`.
+If users want to use private repo, they also need to set up `SCM_USERNAME` and `SCM_ACCESS_TOKEN` as [secrets](/user-guide/configuration/secrets) in their `screwdriver.yaml`.
 
-In order to enable [meta PR comments](../user-guide/metadata), you’ll need to create a bot user in Git with a personal access token with the `public_repo` scope. In Github, create a new user. Follow instructions to [create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line), set the scope as `public_repo`. Copy this token and set it as `commentUserToken` in your `scms` settings in your [API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269).
+In order to enable [meta PR comments](/user-guide/metadata), you’ll need to create a bot user in Git with a personal access token with the `public_repo` scope. In Github, create a new user. Follow instructions to [create a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line), set the scope as `public_repo`. Copy this token and set it as `commentUserToken` in your `scms` settings in your [API config yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L268-L269).
 
 ###### Deploy Keys
 
@@ -590,7 +590,7 @@ Deploy Keys are SSH keys that grant access to a single GitHub repository. This k
 
 If users want to use deploy keys in their pipeline they have 2 options:
 * Enable automatic generation and handling of deploy keys as a part of the pipeline by setting the `autoDeployKeyGeneration` flag to `true` in their `config/local.yaml`. With this flag enabled, the user will get an option to actually trigger the generation in the UI.
-* Manually generate the public and private key pair using `openssl genrsa -out jwt.pem 2048` and `openssl rsa -in jwt.pem -pubout -out jwt.pub`. Now add the public key as a deploy key to the repo. The private key needs to be **base64 encoded** and added as a secret `SD_SCM_DEPLOY_KEY` in the pipeline. Refer [secrets](../../user-guide/configuration/secrets) for adding secrets.
+* Manually generate the public and private key pair using `openssl genrsa -out jwt.pem 2048` and `openssl rsa -in jwt.pem -pubout -out jwt.pub`. Now add the public key as a deploy key to the repo. The private key needs to be **base64 encoded** and added as a secret `SD_SCM_DEPLOY_KEY` in the pipeline. Refer [secrets](/user-guide/configuration/secrets) for adding secrets.
 
 
 ##### Bitbucket.org
@@ -689,7 +689,7 @@ redisLock:
   enabled: true
   options:
     # maximum retry limit to obtain lock
-    retryCount: 200 
+    retryCount: 200
     # the expected clock drift
     driftFactor: 0.01
     # the time in milliseconds between retry attempts

--- a/docs/cluster-management/kubernetes.md
+++ b/docs/cluster-management/kubernetes.md
@@ -3,7 +3,7 @@ layout: main
 title: Kubernetes
 category: Cluster Management
 menu: menu
-toc: 
+toc:
     - title: Setting Up a Screwdriver Cluster on AWS using Kubernetes
       url: "#setting-up-a-screwdriver-cluster-on-aws-using-kubernetes"
       active: true
@@ -158,7 +158,7 @@ You can check out the `api.yaml` in the [Screwdriver config examples repo](https
 A Kubernetes Service is an abstraction which defines a set of Pods and is assigned a unique IP address which persists.
 Follow instructions in [Creating a Service](http://kubernetes.io/docs/user-guide/connecting-applications/#creating-a-service) to set up your `service.yaml`.
 
-It should look like the Service in [api.yaml](https://github.com/screwdriver-cd-test/config-examples/blob/master/kubernetes/api.yaml).
+It should look like the Service in [api.yaml](https://github.com/screwdriver-cd-test/config-examples/blob/master/services/api.yaml).
 
 To create your service, run the `kubectl create` command on your `service.yaml` file:
 ```bash
@@ -193,7 +193,7 @@ $ kubectl describe services sdapi
 ### Create a Deployment
 A Deployment makes sure a specified number of pod “replicas” are running at any one time. If there are too many, it will kill some; if there are too few, it will start more. Follow instructions on the [Deploying Applications](http://kubernetes.io/docs/user-guide/deploying-applications/) page to create your `deployment.yaml`.
 
-It should look like the Deployment in [api.yaml](https://github.com/screwdriver-cd-test/config-examples/blob/master/kubernetes/api.yaml).
+It should look like the Deployment in [api.yaml](https://github.com/screwdriver-cd-test/config-examples/blob/master/services/api.yaml).
 
 ### Deploy
 For a fresh deployment, run the `kubectl create` command on your `deployment.yaml` file:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,6 +7,7 @@ jobs:
     steps:
         - bundle_install: bundle install
         - build: bundle exec jekyll build --source docs --destination _site
+        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --empty-alt-ignore --file-ignore '/\/ja\//' --url-ignore '/bitbucket/,/api\.screwdriver\.cd/' --http-status-ignore 429 _site
 
   publish:
       requires: [main]


### PR DESCRIPTION
After using a different mechanism to find broken links the other day, I
looked for something to be run in coordination with Jekyll, and I found
the html-proof gem.

Most of the options I have included will need to remain. The
--empty-alt-ignore can go away with some alt properties in some images,
and the --file-ignore for all of the ja files can go away with some fixes
in that subdirectory.


## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Broken links are annoying.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This change will run `htmlproofer` for every new pull request.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
