### PR TITLE
fix(2497): Add alt attributes to images

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -20,13 +20,13 @@ A collection of services that facilitate the workflow for continuous delivery pi
         Easily define the path that your code takes from Pull Request to Production.</p>
     </div>
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/continuous_delivery.png" class="cd">
+        <img src="/assets/continuous_delivery.png" class="cd" alt="build publish deploy flowchart">
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/daily_habits.png" class="dh">
+        <img src="/assets/daily_habits.png" class="dh" alt="commit test release cycle">
     </div>
     <div class="col-xs-12 col-md-8">
         <h2>Integrates with Daily Habits</h2>
@@ -44,13 +44,13 @@ A collection of services that facilitate the workflow for continuous delivery pi
         so you can review pipeline changes and roll them out with the rest of your codebase.</p>
     </div>
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/pipeline_code.png" class="pc">
+        <img src="/assets/pipeline_code.png" class="pc" alt="screwdriver.yaml screenshot">
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/3rd_party_services.png" class="party">
+        <img src="/assets/3rd_party_services.png" class="party" alt="third party services examples">
     </div>
     <div class="col-xs-12 col-md-8">
         <h2>Runs Anywhere</h2>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ menu: menu
 is_homepage: true
 ---
 <div class="top">
-    <img src="/assets/Screwdriver_Icon_Full@1x.png">
+    <img src="/assets/Screwdriver_Icon_Full@1x.png" alt="Screwdriver icon">
     <h1>Welcome to Screwdriver!</h1>
     <p>We've split documentation into 3 distinct sections:</p>
 </div>

--- a/docs/ja/about/index.md
+++ b/docs/ja/about/index.md
@@ -20,7 +20,7 @@ toc:
         <p>Screwdriverはあなたのビルドパイプライン上で継続的デリバリーを第一級オブジェクトとして扱います。プルリクエストからプロダクションまでの流れを簡単に定義します。</p>
     </div>
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/continuous_delivery.png" class="cd">
+        <img src="/assets/continuous_delivery.png" class="cd" alt="build publish deploy flowchart">
     </div>
 </div>
 
@@ -28,7 +28,7 @@ toc:
 
 <div class="row">
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/daily_habits.png" class="dh">
+        <img src="/assets/daily_habits.png" class="dh" alt="commit test release cycle">
     </div>
     <div class="col-xs-12 col-md-8">
         <h2>日常業務との統合</h2>
@@ -44,7 +44,7 @@ toc:
         <p>シンプルなYAMLファイルをコードに追加することでパイプラインを定義できます。パイプラインを扱う他の設定は無いため、他のコードと合わせてパイプラインの変更をレビューした上で投入できます。</p>
     </div>
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/pipeline_code.png" class="pc">
+        <img src="/assets/pipeline_code.png" class="pc" alt="Screwdriver.yaml screenshot">
     </div>
 </div>
 
@@ -52,7 +52,7 @@ toc:
 
 <div class="row">
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/3rd_party_services.png" class="party">
+        <img src="/assets/3rd_party_services.png" class="party" alt="third party services examples">
     </div>
     <div class="col-xs-12 col-md-8">
         <h2>あらゆる環境で動作</h2>

--- a/docs/ja/about/index.md
+++ b/docs/ja/about/index.md
@@ -20,7 +20,7 @@ toc:
         <p>Screwdriverはあなたのビルドパイプライン上で継続的デリバリーを第一級オブジェクトとして扱います。プルリクエストからプロダクションまでの流れを簡単に定義します。</p>
     </div>
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/continuous_delivery.png" class="cd" alt="build publish deploy flowchart">
+        <img src="/assets/continuous_delivery.png" class="cd" alt="ビルド、パブリッシュ、デプロイのフローチャート">
     </div>
 </div>
 
@@ -28,7 +28,7 @@ toc:
 
 <div class="row">
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/daily_habits.png" class="dh" alt="commit test release cycle">
+        <img src="/assets/daily_habits.png" class="dh" alt="コミット、テスト、リリースのサイクル">
     </div>
     <div class="col-xs-12 col-md-8">
         <h2>日常業務との統合</h2>
@@ -44,7 +44,7 @@ toc:
         <p>シンプルなYAMLファイルをコードに追加することでパイプラインを定義できます。パイプラインを扱う他の設定は無いため、他のコードと合わせてパイプラインの変更をレビューした上で投入できます。</p>
     </div>
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/pipeline_code.png" class="pc" alt="Screwdriver.yaml screenshot">
+        <img src="/assets/pipeline_code.png" class="pc" alt="screwdriver.yaml のスクリーンショット">
     </div>
 </div>
 
@@ -52,7 +52,7 @@ toc:
 
 <div class="row">
     <div class="col-xs-12 col-md-4">
-        <img src="/assets/3rd_party_services.png" class="party" alt="third party services examples">
+        <img src="/assets/3rd_party_services.png" class="party" alt="対応するサードパーティーサービスの例">
     </div>
     <div class="col-xs-12 col-md-8">
         <h2>あらゆる環境で動作</h2>

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -6,7 +6,7 @@ menu: menu_ja
 is_homepage: 'true'
 ---
 <div class="top">
-    <img src="/assets/Screwdriver_Icon_Full@1x.png" alt="Screwdriver icon">
+    <img src="/assets/Screwdriver_Icon_Full@1x.png" alt="Screwdriverのアイコン">
     <h1>Screwdriverにようこそ</h1>
     <p>ドキュメントは3つの異なるセクションに分かれています</p>
 </div>

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -6,7 +6,7 @@ menu: menu_ja
 is_homepage: 'true'
 ---
 <div class="top">
-    <img src="/assets/Screwdriver_Icon_Full@1x.png">
+    <img src="/assets/Screwdriver_Icon_Full@1x.png" alt="Screwdriver icon">
     <h1>Screwdriverにようこそ</h1>
     <p>ドキュメントは3つの異なるセクションに分かれています</p>
 </div>

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
         - bundle_install: bundle install
         - build: bundle exec jekyll build --source docs --destination _site
-        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --empty-alt-ignore --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/' --http-status-ignore 429 _site
+        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/' --http-status-ignore 429 _site
 
   publish:
       requires: [main]


### PR DESCRIPTION
## Context

It would be nice to have alt attributes for those that cannot see images in our guide.

## Objective

This PR adds alt attributes to images on our main pages.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2497

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
