### PR TITLE
fix: Fix indentation in parameters doc

### DIFF
--- a/docs/user-guide/configuration/parameters.md
+++ b/docs/user-guide/configuration/parameters.md
@@ -52,13 +52,12 @@ parameters:
 ```
 ## Scope
 Parameters can be defined at two scopes:
- - Pipeline
-    - Parameters defined at pipeline level are available to all the jobs
- - Job
-    - Parameters defined at job level are exclusively available to that job.
-    - Parameters with the same name defined at different jobs do not conflict.
-    - When a parameter with the same name is defined at both pipeline and job scopes, value at job scope supercedes the value at pipeline scope.
- 
+* **Pipeline**
+    * Parameters defined at pipeline level are available to all the jobs
+* **Job**
+    * Parameters defined at job level are exclusively available to that job.
+    * Parameters with the same name defined at different jobs do not conflict.
+    * When a parameter with the same name is defined at both pipeline and job scopes, value at job scope supercedes the value at pipeline scope.
 
 ## Example
 You can see a full screwdriver.yaml example below:


### PR DESCRIPTION
## Context

Indentation in `Scope` section of `Parameters` config guide is not rendering as expected.

## Objective

Fix the indentation

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
