### PR TITLE
fix: Add spacing and newlines to try to fix AWS table

### DIFF
--- a/docs/cluster-management/aws-integration.md
+++ b/docs/cluster-management/aws-integration.md
@@ -145,20 +145,21 @@ jobs:
 ```
 
 # Provider Configuration
+
  | Property | Values | Description |
  |------------|--------|-------------|
- | name| `aws` | Name of the supported cloud provider|
- | region    | `us-east-1` / `us-west-2` / [all AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)  | Default value is `us-west-2`. It defines the region where the required infrastructure is setup and where builds will run |
- | accountId | Valid AWS account ID | This defines the AWS account Id where builds will be provisioned |
- |vpcId | Valid AWS VPC ID | This defines the AWS VPC Id |
- |securityGroupIds | List of valid security group ids | This defines the AWS Security Group Id |
- |subnetIds | List of valid subnet ids | This defines the AWS Subnet Id |
- |role | ARN of a valid AWS IAM role  | This defines the AWS IAM Role ARN with permissions and policies |
- | executor | `sls` and `eks` | Defines the two executor modes for native builds sls:AWS codebuild  and eks: AWS EKS |
- | launcherImage | Valid Screwdriver launcher docker image | This defines the screwdriver lancher image required for starting builds `e.g: screwdrivercd/launcher:v6.0.149`| 
-| launcherVersion| `e.g: v6.0.149` | Version of the screwdriver launcher image |
-| buildRegion| `us-east-1` / `us-west-2` | Region where builds will run if different from service region. Default value is same as `region`. |
-| executorLogs| `true` / `false` | Flag to view logs in AWS Cloudwatch for the AWS CodeBuild project. Default value is `false`. |
-| privilegedMode| `true` / `false` | Flag to enable privileged mode for docker build in the AWS CodeBuild project. Default value is `false`. |
-| computeType| All supported [AWS CodeBuild Compute Types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) | Default value is `BUILD_GENERAL1_SMALL`. This defines the different compute types with available memory, vCPUs, and disk space  |
-| environment| All supported [AWS CodeBuild Environment](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) | Default value is `LINUX_CONTAINER`. This defines the different environment types corresponding with `computeType`|
+ | name | `aws` | Name of the supported cloud provider |
+ | region | `us-east-1` / `us-west-2` / [all AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) | Default value is `us-west-2`. It defines the region where the required infrastructure is setup and where builds will run |
+ | accountId | Valid AWS account ID | This defines the AWS account ID where builds will be provisioned |
+ | vpcId | Valid AWS VPC ID | This defines the AWS VPC ID |
+ | securityGroupIds | List of valid security group IDs | This defines the AWS Security Group Id |
+ | subnetIds | List of valid subnet IDs | This defines the AWS Subnet ID |
+ | role | ARN of a valid AWS IAM role  | This defines the AWS IAM Role ARN with permissions and policies |
+ | executor | `sls` / `eks` | Defines the two executor modes for native builds: `sls` (AWS CodeBuild) and `eks` (AWS EKS). |
+ | launcherImage | Valid Screwdriver launcher Docker image | This defines the Screwdriver launcher image required for starting builds `e.g: screwdrivercd/launcher:v6.0.149` |
+ | launcherVersion | e.g: `v6.0.149` | Version of the Screwdriver launcher image |
+ | buildRegion | `us-east-1` / `us-west-2` | Region where builds will run if different from service region. Default value is same as `region`. |
+ | executorLogs | `true` / `false` | Flag to view logs in AWS CloudWatch for the AWS CodeBuild project. Default value is `false`. |
+ | privilegedMode | `true` / `false` | Flag to enable privileged mode for Docker build in the AWS CodeBuild project. Default value is `false`. |
+ | computeType | All supported [AWS CodeBuild Compute Types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) | This defines the different compute types with available memory, vCPUs, and disk space. Default value is `BUILD_GENERAL1_SMALL`.   |
+ | environment | All supported [AWS CodeBuild Environment](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) | This defines the different environment types corresponding with `computeType`. Default value is `LINUX_CONTAINER`. |


### PR DESCRIPTION
## Context
The table is misformatted:
<img width="880" alt="Screen Shot 2022-02-25 at 12 22 04 PM" src="https://user-images.githubusercontent.com/3230529/155796064-a916ae5f-94d0-4bc0-86e6-09bd93ea0e77.png">


## Objective

See if adding newline at beginning of table and preceding space will fix table formatting. Also fix some capitalization.

## References

Related to https://github.com/screwdriver-cd/guide/pull/517

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
