### PR TITLE
fix: Add jobDisabledByDefault annotation

### DIFF
--- a/docs/cluster-management/aws-integration.md
+++ b/docs/cluster-management/aws-integration.md
@@ -66,18 +66,6 @@ jobs:
       - init: npm install
       - test: npm test
 ```
-#### Example
-Alternatively, provider configuration can be stored remotely in another repo. You can reference this config by putting a checkout URL with the format `CHECKOUT_URL#BRANCH:PATH`.
-```
-jobs:
-  main:
-    requires: [~pr, ~commit]
-    image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-    provider: git@github.com:configs/aws.git#main:cd/aws/provider.yaml
-    steps:
-      - init: npm install
-      - test: npm test
-```
 
 #### Example
 Alternatively, provider configuration can be stored remotely in another repo. You can reference this config by putting a checkout URL with the format `CHECKOUT_URL#BRANCH:PATH`.

--- a/docs/cluster-management/aws-integration.md
+++ b/docs/cluster-management/aws-integration.md
@@ -66,6 +66,18 @@ jobs:
       - init: npm install
       - test: npm test
 ```
+#### Example
+Alternatively, provider configuration can be stored remotely in another repo. You can reference this config by putting a checkout URL with the format `CHECKOUT_URL#BRANCH:PATH`.
+```
+jobs:
+  main:
+    requires: [~pr, ~commit]
+    image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    provider: git@github.com:configs/aws.git#main:cd/aws/provider.yaml
+    steps:
+      - init: npm install
+      - test: npm test
+```
 
 #### Example
 Alternatively, provider configuration can be stored remotely in another repo. You can reference this config by putting a checkout URL with the format `CHECKOUT_URL#BRANCH:PATH`.

--- a/docs/user-guide/configuration/annotations.md
+++ b/docs/user-guide/configuration/annotations.md
@@ -60,6 +60,7 @@ The following annotations are supported by plugins maintained by Screwdriver.cd.
 | screwdriver.cd/terminationGracePeriodSeconds | Number of seconds | This will allow the user to choose the number of seconds a build should wait before aborting to execute the teardown steps. Default is `'60'` seconds and Max is `'120'` seconds. In most cases more than default will not be required. |
 | screwdriver.cd/blockedBySameJob | `true` / `false` | Setting it to `false` will allow builds from same job to run concurrently with a default wait time of 5 minute, waiting time can be specified by setting `screwdriver.cd/blockedBySameJobWaitTime`. |
 | screwdriver.cd/blockedBySameJobWaitTime | Number of minutes | Concurrent builds will have 5 minute of wait time by default, set this annotation to override wait time. |
+| screwdriver.cd/jobDisabledByDefault | `true` / `false` | When writing a Screwdriver yaml file, you might want to prevent people forking or copying the config from running a configured periodic build. The job will be disabled upon creation when this is set to `true`. Default is `false`. The user can go to the Screwdriver UI options page to enable the job. |
 
 ## Pipeline-Level Annotations
 


### PR DESCRIPTION
## Context

Sometimes users might have repos/pipelines with build periodic configs. If developers fork and create their own pipelines, they might not want these cron jobs to get auto triggered. It would be nice to have an additional annotation for disabling jobs upon creation so users are required to consciously enable them if they want the periodic builds.

## Objective

This PR adds the new `jobDisabledByDefault` annotation.

## References

Related to https://github.com/screwdriver-cd/models/pull/539, https://github.com/screwdriver-cd/data-schema/pull/488
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
