### PR TITLE
feat(2709): Add usage of self-hosted Sonar

### DIFF
--- a/docs/ja/user-guide/configuration/code-coverage.md
+++ b/docs/ja/user-guide/configuration/code-coverage.md
@@ -49,7 +49,7 @@ shared:
 jobs:
   main:
     requires: [~pr, ~commit]
-    image: node:8
+    image: node:14
     steps:
       - install: npm install
       - test: npm test
@@ -59,6 +59,31 @@ jobs:
 
 - `sonar-project.properties` と `$SD_SONAR_OPTS` で同じプロパティを設定していた場合、`$SD_SONAR_OPTS` の設定が優先されます。
 - Screwdriver は次のプロパティ(`sonar.host.url`, `sonar.login`, `sonar.projectKey`, `sonar.projectName`, `sonar.projectVersion`, `sonar.links.scm`, `sonar.links.ci`)を自動で設定します。**`sonar.sources` は自分で設定する必要があります。**
+
+### セルフホスト型のSonarQubeを利用する
+
+環境変数 `$SD_SELF_SONAR_HOST` に Sonar ホストの URL を設定することで、Screwdriver クラスタに設定されているものではないホストにコードカバレッジをアップロードすることができます。  
+`$SD_SELF_SONAR_HOST` を使用する場合、そのホストの admin の User Token を環境変数 `$SD_SELF_SONAR_ADMIN_TOKEN` に設定する必要があります。
+
+`screwdriver.yaml` の例:
+
+```yaml
+jobs:
+  main:
+    requires: [~pr, ~commit]
+    image: node:14
+    steps:
+      - install: npm install
+      - test: npm test
+  environment:
+    SD_SELF_SONAR_HOST: 'http://YOUR_SONAR_URL'
+  secrets:
+    - SD_SELF_SONAR_ADMIN_TOKEN
+```
+
+#### 注意
+
+- `SD_SELF_SONAR_HOST` にコードカバレッジをアップロードした場合、UI上でのコードカバレッジ率の表示は `N/A` となります。
 
 #### 関連リンク
 - [SonarQube properties](https://docs.sonarqube.org/latest/analysis/analysis-parameters)

--- a/docs/user-guide/configuration/code-coverage.md
+++ b/docs/user-guide/configuration/code-coverage.md
@@ -49,7 +49,7 @@ shared:
 jobs:
   main:
     requires: [~pr, ~commit]
-    image: node:8
+    image: node:14
     steps:
       - install: npm install
       - test: npm test
@@ -59,6 +59,31 @@ jobs:
 
 - If you define the same property in both the `sonar-project.properties` file and `$SD_SONAR_OPTS`, `$SD_SONAR_OPTS` will override the properties file.
 - Screwdriver sets the following properties for you: `sonar.host.url`, `sonar.login`, `sonar.projectKey`, `sonar.projectName`, `sonar.projectVersion`, `sonar.links.scm`, `sonar.links.ci`; **you must set `sonar.sources` yourself**.
+
+### Use a self-hosted SonarQube
+
+You can upload code coverage to a host that is not configured for the Screwdriver cluster by setting the Sonar host URL in the environment variable `$SD_SELF_SONAR_HOST`.  
+If you use `$SD_SELF_SONAR_HOST`, you must set the admin's User Token for that host in the environment variable `$SD_SELF_SONAR_ADMIN_TOKEN`.
+
+Example `screwdriver.yaml`:
+
+```yaml
+jobs:
+  main:
+    requires: [~pr, ~commit]
+    image: node:14
+    steps:
+      - install: npm install
+      - test: npm test
+  environment:
+    SD_SELF_SONAR_HOST: 'http://YOUR_SONAR_URL'
+  secrets:
+    - SD_SELF_SONAR_ADMIN_TOKEN
+```
+
+#### Notes
+
+- If you upload code coverage to `$SD_SELF_SONAR_HOST`, the code coverage percentage displayed on the UI will be `N/A`.
 
 #### Related links
 - [SonarQube properties](https://docs.sonarqube.org/latest/analysis/analysis-parameters)


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
With these modifications, self-hosted Sonar is now available from environment variables, and I add an explanation of how to use it.
- https://github.com/screwdriver-cd/coverage-sonar/pull/67
- https://github.com/screwdriver-cd/screwdriver/pull/2731

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2709

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
