### PR TITLE
Update code-coverage.md

### DIFF
--- a/docs/user-guide/configuration/code-coverage.md
+++ b/docs/user-guide/configuration/code-coverage.md
@@ -8,6 +8,9 @@ toc:
       url: "#code-coverage"
     - title: SonarQube
       url: "#sonarqube"
+    - title: Self-hosted SonarQube
+      url: "#use-a-self-hosted-sonarqube"
+      subitem: true
     - title: GitHub PR decoration
       url: "#github-pull-request-decoration"
       subitem: true

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -55,6 +55,7 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 | SD_PRIVATE_PIPELINE | Whether the pipeline is private(true) or not(false) |
 | SD_PULL_REQUEST | Pull Request number (e.g.: `1`; blank if non-PR) |
 | SD_STEP_EXIT_CODE | Exit code from previously executed steps, only available at teardown steps (e.g.: `0` if all previous steps have passed, otherwise, the latest non-zero exit code) |
+| SD_STEP_NAME | Current step name, only available for user-defined steps, not setup or teardown commands (e.g.: during teardown, would be set to the last successfully executed step) |
 | SD_TEMPLATE_FULLNAME | Full template name the job is using (e.g.: `d2lam/myTemplate`; blank if not using template) |
 | SD_TEMPLATE_NAME | Name of the template the job is using (e.g.: `myTemplate`; blank if not using template) |
 | SD_TEMPLATE_NAMESPACE | Namespace of the template the job is using (e.g.: `d2lam`; blank if not using template) |

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
         - bundle_install: bundle install
         - build: bundle exec jekyll build --source docs --destination _site
-        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/,/docs\.github\.com/' --http-status-ignore 429 _site
+        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/,/docs\.github\.com/,/opensource\.org/' --http-status-ignore 429 _site
 
   publish:
       image: ruby:2


### PR DESCRIPTION
## Objective

Add self-hosted Sonar to TOC
Also add SD_STEP_NAME environment variable 

## References

Related to https://github.com/screwdriver-cd/guide/pull/542

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
