### PR TITLE
fix: gem install public_suffix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
   # General clean-up
   && rm -rf guide.tgz \
   # Need jekyll to serve the pages
-  && gem install jekyll
+  && gem install public_suffix:4.0.7 jekyll
 
 EXPOSE 4000
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

`jekyll` requires `public_suffix:4.0.7` in the following build log.
https://cd.screwdriver.cd/pipelines/27/builds/817588/steps/build-push

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Install `public_suffix:4.0.7` before `jekyll`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
