### PR TITLE
fix: add template to mergeSharedSteps example

### DIFF
--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -210,6 +210,7 @@ The following example defines a merged shared configuration for `image` and `ste
 ```yaml
 shared:
     image: node:8
+    template: nodejs/test
     steps:
         - init: npm install
         - pretest: npm lint
@@ -244,6 +245,7 @@ jobs:
         requires: [main]
         image: node:8
         steps:
+             - init: npm install
              - pretest: npm lint
              - test: echo Skipping test
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add missing template in the mergeSharedSteps example, because of annotation `screwdriver.cd/mergeSharedSteps: true` only applies when the template is used, see https://github.com/screwdriver-cd/screwdriver/issues/2174#issuecomment-718405017

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
![image](https://user-images.githubusercontent.com/15989893/191573662-7c5c54dc-3e91-40a3-9edc-ef0c6f8b9e18.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
