### PR TITLE
fix: TOC for aws native builds docs

### DIFF
--- a/docs/cluster-management/aws-integration.md
+++ b/docs/cluster-management/aws-integration.md
@@ -68,6 +68,18 @@ jobs:
       - init: npm install
       - test: npm test
 ```
+#### Example
+Alternatively, provider configuration can be stored remotely in another repo. You can reference this config by putting a checkout URL with the format `CHECKOUT_URL#BRANCH:PATH`.
+```
+jobs:
+  main:
+    requires: [~pr, ~commit]
+    image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    provider: git@github.com:configs/aws.git#main:cd/aws/provider.yaml
+    steps:
+      - init: npm install
+      - test: npm test
+```
 
 #### Example
 Alternatively, provider configuration can be stored remotely in another repo. You can reference this external provider config by putting a checkout URL with the format `CHECKOUT_URL#BRANCH:PATH`.


### PR DESCRIPTION
## Context

TOC is not complete for AWS native builds docs

## Objective

This PR cleans up TOC and fixes up the hierarchy of titles a bit.

## References

Related to https://github.com/screwdriver-cd/guide/pull/549

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
