### PR TITLE
fix: breaking change commit format instructions

### DIFF
--- a/docs/about/contributing/index.md
+++ b/docs/about/contributing/index.md
@@ -13,6 +13,9 @@ toc:
       url: "#general-guidelines-for-contributing"
     - title: Submitting Pull Requests
       url: "#submitting-pull-requests"
+    - title: Commit Message Format
+      url: "#commit-message-format"
+      subitem: true
 ---
 # Contributing
 
@@ -52,9 +55,9 @@ We use [semantic-release](https://www.npmjs.com/package/semantic-release), which
 | Scope | anything that specifies the scope of the commit; can be blank, the issue number that your commit pertains to, or `*` |
 | Subject | description of the commit |
 
-**Important:** For any **breaking changes** that require a major version bump, add `BREAKING CHANGE: MESSAGE` somewhere in the commit title or message, also commit type must be `feat`.
+**Important:** For any **breaking changes** that require a major version bump, add `BREAKING CHANGE: <message>` at the end of the commit title or message. Type must be `feat`.
 
-**Examples commit titles:**
+**Example commit titles:**
 * For a bug fix: `fix: Remove extra space`
 * For a breaking change: `feat(scm): Support new scm plugin. BREAKING CHANGE: github no longer works`
 

--- a/docs/about/contributing/index.md
+++ b/docs/about/contributing/index.md
@@ -57,7 +57,7 @@ We use [semantic-release](https://www.npmjs.com/package/semantic-release), which
 
 **Important:** For any **breaking changes** that require a major version bump, add `BREAKING CHANGE: <message>` preceded by a space or two newlines in the footer of the commit message. The rest of the commit message is then used for this.
 
-**Example commit titles:**
+**Example commit messages:**
 * For a bug fix: `fix: Remove extra space`
 * For a breaking change:
 ```

--- a/docs/about/contributing/index.md
+++ b/docs/about/contributing/index.md
@@ -55,11 +55,18 @@ We use [semantic-release](https://www.npmjs.com/package/semantic-release), which
 | Scope | anything that specifies the scope of the commit; can be blank, the issue number that your commit pertains to, or `*` |
 | Subject | description of the commit |
 
-**Important:** For any **breaking changes** that require a major version bump, add `BREAKING CHANGE: <message>` at the end of the commit title or message. Type must be `feat`.
+**Important:** For any **breaking changes** that require a major version bump, add `BREAKING CHANGE: <message>` preceded by a space or two newlines in the footer of the commit message. The rest of the commit message is then used for this.
 
 **Example commit titles:**
 * For a bug fix: `fix: Remove extra space`
-* For a breaking change: `feat(scm): Support new scm plugin. BREAKING CHANGE: github no longer works`
+* For a breaking change:
+```
+feat(1234): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed.
+
+The default graphite width of 10mm is always used for performance reasons.
+```
 
 [api-issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
 [api-repo]: https://github.com/screwdriver-cd/screwdriver


### PR DESCRIPTION
## Context

Instructions for breaking change commit format can be confusing.

## Objective

This PR attempts to clarify breaking change commit format.

## References

Related to https://github.com/semantic-release/semantic-release/blob/master/CONTRIBUTING.md#footer

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
