### PR TITLE
fix: documentation file that has relative path issue

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -190,7 +190,7 @@ In order to use Sonar in your cluster, set up a Sonar server (see example at [ou
 | COVERAGE_SONAR_HOST | Yes  | Sonar host URL        |
 | COVERAGE_SONAR_ADMIN_TOKEN | Yes | Sonar admin token |
 | COVERAGE_SONAR_ENTERPRISE | No | Whether using Enterprise(true) or open source edition of SonarQube(false); default `false` |
-| COVERAGE_SONAR_GIT_APP_NAME | No | Github app name for Sonar pull request decoration; default `Screwdriver Sonar PR Checks`; This feature requires Sonar enterprise edition. Follow [instructions in the Sonar docs](https://docs.sonarqube.org/latest/analysis/pr-decoration) for details. |
+| COVERAGE_SONAR_GIT_APP_NAME | No | Github app name for Sonar pull request decoration; default `Screwdriver Sonar PR Checks`; This feature requires Sonar enterprise edition. Follow [instructions in the Sonar docs](https://docs.sonarqube.org/latest/analyzing-source-code/pull-request-analysis) for details. |
 
 You’ll also need to add the `screwdriver-coverage-bookend` along with the `screwdriver-artifact-bookend` as teardown bookends by setting the `BOOKENDS` variable (in JSON format). See the Bookend Plugins section above for more details. Using Enterprise edition of SonarQube will default to _pipeline_ scope for SonarQube project keys and names. Will also allow for usage of PR analysis and prevent creation of separate projects for each Screwdriver job. Using non-Enterprise SonarQube will default to _job_ scope for SonarQube project keys and names.
 

--- a/docs/cluster-management/zip-artifacts.md
+++ b/docs/cluster-management/zip-artifacts.md
@@ -27,7 +27,7 @@ It takes time for the uploaded files to appear on UI, because the ZIP file is up
 
 ## Architecture
 
-![zip artifacts architecture](../../cluster-management/assets/zip-artifacts-architecture.png)  
+![zip artifacts architecture](../cluster-management/assets/zip-artifacts-architecture.png)  
 
 1. Build container(`screwdriver-artifact-bookend` step) uploads a zipped build artifact.
 1. Build container sends request to API to unzip the zipped file.

--- a/docs/ja/cluster-management/configure-api.md
+++ b/docs/ja/cluster-management/configure-api.md
@@ -190,7 +190,7 @@ bookends:
 | COVERAGE_SONAR_HOST | はい | Sonar の host の URL |
 | COVERAGE_SONAR_ADMIN_TOKEN | はい | Sonar の admin token |
 | COVERAGE_SONAR_ENTERPRISE | いいえ | SonarQube を Enterprise 版で利用している(true)か、OpenSourceEdition で利用している(false）か。デフォルト値は `false` |
-| COVERAGE_SONAR_GIT_APP_NAME | いいえ | SonarのPull Request DecorationのためのGithub app名。デフォルト値は `Screwdriver Sonar PR Checks` です。この機能にはSonar Enterprise Editionが必要です。詳細は[Sonarのドキュメント](https://docs.sonarqube.org/latest/analysis/pr-decoration)をご覧ください。
+| COVERAGE_SONAR_GIT_APP_NAME | いいえ | SonarのPull Request DecorationのためのGithub app名。デフォルト値は `Screwdriver Sonar PR Checks` です。この機能にはSonar Enterprise Editionが必要です。詳細は[Sonarのドキュメント](https://docs.sonarqube.org/latest/analyzing-source-code/pull-request-analysis)をご覧ください。
 
 更に `screwdriver-artifact-bookend` に加えて、`screwdriver-coverage-bookend` も `BOOKENDS` の環境変数に JSON フォーマットで teardown bookend として設定する必要があります。詳しくは、上の Bookend Plugins の節を見てください。SonarQube の Enterprise 版を利用している場合には、 SonarQube のプロジェクトキーや名前はデフォルトでは _パイプライン_ スコープになります。これにより、 PR 解析が使えるようになったり、 Screwdriver のジョブ毎に個別のプロジェクトが作成されることを防げます。Enterprise 版の SonarQube を使用していない場合、SonarQube のプロジェクトキーや名前はデフォルトでは _ジョブ_ スコープになります。
 

--- a/docs/ja/user-guide/configuration/code-coverage.md
+++ b/docs/ja/user-guide/configuration/code-coverage.md
@@ -97,4 +97,4 @@ jobs:
 - [SonarQube environment variables](../environment-variables#カバレッジsonar)
 
 ### GitHub pull request decoration
-ScrewdriverのクラスタがSonar Enterpriseを利用している場合、GitHubでのチェックに[Pull Request decoration](https://docs.sonarqube.org/7.8/analysis/pull-request/)を利用することができます。この機能が有効な場合、リポジトリにSonar PR Checks用のGitHub appを追加することで利用することが出来ます。サポート状況の詳細はScrewdriverクラスタ管理者に確認してください。
+ScrewdriverのクラスタがSonar Enterpriseを利用している場合、GitHubでのチェックに[Pull Request decoration](https://docs.sonarqube.org/latest/analyzing-source-code/pull-request-analysis/)を利用することができます。この機能が有効な場合、リポジトリにSonar PR Checks用のGitHub appを追加することで利用することが出来ます。サポート状況の詳細はScrewdriverクラスタ管理者に確認してください。

--- a/docs/user-guide/configuration/code-coverage.md
+++ b/docs/user-guide/configuration/code-coverage.md
@@ -97,4 +97,4 @@ jobs:
 - [SonarQube environment variables](../environment-variables#coverage-sonar)
 
 ### GitHub pull request decoration
-If your Screwdriver cluster supports Sonar Enterprise, you might have the ability to add [Pull Request decoration](https://docs.sonarqube.org/7.8/analysis/pull-request/) to Checks in GitHub. If this feature is supported, you can enable it by adding the Screwdriver Sonar PR Checks GitHub app to your repository. Check with your Screwdriver cluster admin for support details.
+If your Screwdriver cluster supports Sonar Enterprise, you might have the ability to add [Pull Request decoration](https://docs.sonarqube.org/latest/analyzing-source-code/pull-request-analysis/) to Checks in GitHub. If this feature is supported, you can enable it by adding the Screwdriver Sonar PR Checks GitHub app to your repository. Check with your Screwdriver cluster admin for support details.


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->



```
 WARNING  -  Documentation file 'cluster-management/zip-artifacts.md' contains a link to '../cluster-management/assets/zip-artifacts-architecture.png' which is not found in the documentation files.
```

Issue: 

![image](https://user-images.githubusercontent.com/15989893/207170861-d39fac15-7f28-4f67-b7ea-501346ee3965.png)


## Objective
This fixes the relative path
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
