### PR TITLE
fix: Update Ruby (RubyGem) version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.6-alpine
+FROM ruby:3.1.3-alpine
 
 # Create our application directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
## Context

`docker-publish` Screwdriver job failed with below error
```
11:25:06 ERROR:  Error installing jekyll:
11:25:06 	The last version of sass-embedded (~> 1.54) to support your Ruby & RubyGems was 1.57.1. Try installing it with `gem install sass-embedded -v 1.57.1` and then running the current command again
11:25:06 	sass-embedded requires RubyGems version >= 3.3.22. The current RubyGems version is 3.1.6. Try 'gem update --system' to update RubyGems itself.
```

https://cd.screwdriver.cd/pipelines/27/builds/841010/steps/build-push

## Objective

Updating the base image to `ruby:3.1.3-alpine` which contains RubyGem `3.3.26`

## References



## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
