### PR TITLE
fix(2700): Add audit log docs for API cluster

### DIFF
--- a/docs/cluster-management/configure-api.md
+++ b/docs/cluster-management/configure-api.md
@@ -50,6 +50,9 @@ toc:
     - title: Configure Redis Lock
       url: "#configure-redis-lock"
       subitem: true
+    - title: Logging
+      url: "#logging"
+      subitem: true
     - title: Extending the Docker container
       url: "#extending-the-docker-container"
 ---
@@ -768,6 +771,30 @@ redisLock:
             tls: false
         database: 0
         prefix: ""
+```
+
+### Logging
+For more verbose or precise logging, you can configure these environment variables:
+
+| Environment Variable      | Required            | Default              | Description       |
+|:--------------------------|:--------------------|:---------------------|:-----------------------------|
+| LOG_AUDIT_ENABLED         | No                  | false                | Enable audit logs for all API calls            |
+| LOG_AUDIT_SCOPE           | No                  | []                   | Target token scopes (e.g. pipeline, build, temporal, admin, guest, user) |
+
+```yaml
+# config/local.yaml
+log:
+  audit:
+    # set true to enable audit logs for all API calls
+    enabled: false
+    # add target scope tokens(pipeline, build, temporal, admin, guest, user)
+    scope: []
+```
+
+Example output logs:
+```
+{"level":"info","message":"[Login] User tkyi get /v4/events/41/builds","timestamp":"2022-11-04T22:19:33.039Z"}
+{"level":"info","message":"[Login] Pipeline 7 post /v4/pipelines/7/sync","timestamp":"2022-11-04T22:19:33.985Z"}
 ```
 
 ## Extending the Docker container


### PR DESCRIPTION
## Objective

This PR adds audit log documentation for API cluster admins.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2784

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
