### PR TITLE
fix: add github and kubernetes.io to ignore files

### DIFF
--- a/docs/ja/user-guide/environment-variables.md
+++ b/docs/ja/user-guide/environment-variables.md
@@ -61,6 +61,7 @@ Screwdriver はビルドの過程で利用できる環境変数をエクスポ�
 | SD_TEMPLATE_NAME | 使用しているテンプレートの名前 (テンプレートを使用していない場合は空) |
 | SD_TEMPLATE_NAMESPACE | 使用しているテンプレートのネームスペース (テンプレートを使用していない場合は空) |
 | SD_TEMPLATE_VERSION | 使用しているテンプレートのバージョン (テンプレートを使用していない場合は空) |
+| SD_BUILD_CLUSTER_NAME | 使用している[ビルドクラスター](../cluster-management/configure-buildcluster-queue-worker)の名前 |
 | SD_TOKEN | ビルド用の JWT トークン |
 | SD_SCHEDULED_BUILD | スケジューラーによってビルドを開始する(true)か、否(false)か |
 | SD_DIND_SHARE_PATH | Docker-in-Docker機能が有効な場合に使われる。ビルドコンテナとDinDコンテナの共有ディレクトリへのパス |

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -60,6 +60,7 @@ _Note: Environment variables set in one job cannot be accessed in another job. T
 | SD_TEMPLATE_NAME | Name of the template the job is using (e.g.: `myTemplate`; blank if not using template) |
 | SD_TEMPLATE_NAMESPACE | Namespace of the template the job is using (e.g.: `d2lam`; blank if not using template) |
 | SD_TEMPLATE_VERSION | Version of the template the job is using (blank if not using template) |
+| SD_BUILD_CLUSTER_NAME | The name of the [build cluster](../cluster-management/configure-buildcluster-queue-worker) |
 | SD_TOKEN | JWT token for the build |
 | SD_SCHEDULED_BUILD | Whether the build is triggered by scheduler(true) or not(false) |
 | SD_DIND_SHARE_PATH | Path to shared directory between build container and DinD container when Docker-in-Docker feature is enabled |

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
         - bundle_install: bundle install
         - build: bundle exec jekyll build --source docs --destination _site
-        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/,/docs\.github\.com/,/opensource\.org/' --http-status-ignore 429 _site
+        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/,/github\.com/,/kubernetes\.io/,/opensource\.org/' --http-status-ignore 429 _site
 
   publish:
       image: ruby:2


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Just trying to fix some issue that happened in https://github.com/screwdriver-cd/guide/pull/567

Add `github.com` and `kubernetes.io` to ignore files changed:
Failure: https://cd.screwdriver.cd/pipelines/27/builds/853503/steps/proof
To
Success: https://cd.screwdriver.cd/pipelines/27/builds/853510/steps/proof

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
