### PR TITLE
docs: clarify non-globbing sourcePaths

### DIFF
--- a/docs/user-guide/configuration/sourceDirectory.md
+++ b/docs/user-guide/configuration/sourceDirectory.md
@@ -44,7 +44,7 @@ In this example, jobs that `requires: [~commit, ~pr]` will be triggered if there
 Example repo: <https://github.com/screwdriver-cd-test/source-dir-example>
 
 ### Caveats
-- If you use [sourcePaths](sourcePaths) together with custom source directory, the scope of the `sourcePaths` is limited to your source directory. You can not listen on changes that are outside your source directory. ***Note*** the path for your `sourcePaths` is relative to the root of the repository, not your source directory.
+- If you use [sourcePaths](sourcePaths) together with custom source directory, the scope of the `sourcePaths` is limited to your source directory. You cannot listen on changes that are outside your source directory. ***Note*** the path for your `sourcePaths` is relative to the root of the repository, not your source directory.
 
   - For example, if you want to add sourcePaths to listen on changes to `main.js` and `screwdriver.yaml`, you should set:
 ```

--- a/docs/user-guide/configuration/sourcePaths.md
+++ b/docs/user-guide/configuration/sourcePaths.md
@@ -72,4 +72,5 @@ In this example, the job `main` will be triggered if there are any changes to fi
 ### Caveats
 - This feature is only available for the [Github SCM](https://github.com/screwdriver-cd/scm-github) right now.
 - `sourcePaths` will be ignored if you manually start a pipeline or restart a job.
-- The `screwdriver.yaml` must still be located at root.
+- `screwdriver.yaml` must still be located at root.
+- `sourcePaths` does not support wildcards or globs.


### PR DESCRIPTION
plus a random s/can not/cannot/


## Context

I sometimes wonder whether `sourcePaths` can use globs.

## Objective

Explicitly note the lack of globbing in `sourcePaths`

## References

Various Slack messages.
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
