### PR TITLE
fixing docs typo for queue and store service

### DIFF
--- a/docs/cluster-management/configure-queue-service.md
+++ b/docs/cluster-management/configure-queue-service.md
@@ -37,7 +37,7 @@ toc:
 
 ## Packages
 
-Like the other services, the API is shipped as a [Docker image](https://hub.docker.com/r/screwdrivercd/queue-service/) with port 80 exposed.
+Like the other services, the Queue service is shipped as a [Docker image](https://hub.docker.com/r/screwdrivercd/queue-service/) with port 80 exposed.
 
 ```bash
 $ docker run -d -p 9003:80 screwdrivercd/queue-service:latest

--- a/docs/cluster-management/configure-store.md
+++ b/docs/cluster-management/configure-store.md
@@ -28,7 +28,7 @@ toc:
 
 ## Packages
 
-Like the other services, the API is shipped as a [Docker image](https://hub.docker.com/r/screwdrivercd/store/) with port 80 exposed.
+Like the other services, the Store is shipped as a [Docker image](https://hub.docker.com/r/screwdrivercd/store/) with port 80 exposed.
 
 ```bash
 $ docker run -d -p 7000:80 screwdrivercd/store:stable


### PR DESCRIPTION
## Context
Fixing the introductory typo in queue and store service configuration docs. 

## Objective
I believe the `API` mentioned in the  queue and store service configuration docs should refer to `Queue service` and `Store` respectively. 

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
