### PR TITLE
Add link to Slack's Advanced Formatting Documentation for messages

### DIFF
--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -250,6 +250,8 @@ Result:
 
 You can customize [notification](./configuration/settings.html#slack) messages with meta. Meta keys are different for each notification plugin.
 
+Slack requires special string formatting including a mention or channel link in the message. You can read more about the available options in the [Slack Documentation](https://api.slack.com/reference/surfaces/formatting#advanced).
+
 #### Basic
 Example screwdriver.yaml notifying with Slack:
 ```yaml

--- a/docs/user-guide/metadata.md
+++ b/docs/user-guide/metadata.md
@@ -250,7 +250,7 @@ Result:
 
 You can customize [notification](./configuration/settings.html#slack) messages with meta. Meta keys are different for each notification plugin.
 
-Slack requires special string formatting including a mention or channel link in the message. You can read more about the available options in the [Slack Documentation](https://api.slack.com/reference/surfaces/formatting#advanced).
+You will need special string formatting for mentions or channel links in Slack. You can read more about the available options in the [Slack Documentation](https://api.slack.com/reference/surfaces/formatting#advanced).
 
 #### Basic
 Example screwdriver.yaml notifying with Slack:


### PR DESCRIPTION
## Context
The notification message for Slack alerts can include links to channels, user mentions, user group mentions, and special mentions (i.e. `@here` or `@channel`), but each has a specific format they need to follow to work correctly. The examples in the documentation only cover the syntax for user mentions, so this can lead readers to believe that this is the only option supported and/or that the syntax is the same for all actions. 
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Made a change to the documentation which clarifies that there are multiple options available and includes a link to Slack's documentation for more details.
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
