### PR TITLE
fix: upgrade the ruby image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.6-alpine
+FROM ruby:3.3.4-alpine
 
 # Create our application directory
 RUN mkdir -p /usr/src/app
@@ -13,8 +13,8 @@ RUN set -x \
   && apk add --no-cache --virtual ca-certificates wget \
   # Fetch the latest Guide release
   && wget -q -O - https://api.github.com/repos/screwdriver-cd/guide/releases/latest \
-      | egrep -o '/screwdriver-cd/guide/releases/download/v[0-9.]*/guide.tgz' \
-      | wget --base=http://github.com/ -i - -O guide.tgz \
+  | egrep -o '/screwdriver-cd/guide/releases/download/v[0-9.]*/guide.tgz' \
+  | wget --base=http://github.com/ -i - -O guide.tgz \
   && tar -zxvf guide.tgz \
   # General clean-up
   && rm -rf guide.tgz \


### PR DESCRIPTION
## Context

The ruby image used in Dockerfile is now outdated. 

## Objective

Upgrade to the higher version of Ruby. 

## References

Fail pipeline due to the image too old. 
https://cd.screwdriver.cd/pipelines/27/events/812387

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.