### PR TITLE
fix: gem update when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ruby:3.3.4-alpine
+FROM ruby:2.7.6-alpine
+
+# Update RubyGems
+RUN gem update --system 3.3.22
 
 # Create our application directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
## Context

The container is unable to start as the [jekyll](jekyll:4.2.2) version is not compatible with the new ruby image ruby:3.3.4-alpine

## Objective

The previous [build](https://cd.screwdriver.cd/pipelines/27/builds/952050/steps/build-push) that failed actually indicated that the version of gem is too old hence it is not compatible with some dependencies, hence updating gem would solve it. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
