### PR TITLE
feat: giving a hyperlink to caveats of remote workflow

### DIFF
--- a/docs/user-guide/configuration/workflow.md
+++ b/docs/user-guide/configuration/workflow.md
@@ -24,6 +24,8 @@ toc:
     url: "#remote-triggers"
   - title: Remote Join
     url: "#remote-join"
+  - title: Caveats
+    url: "#caveats"
   - title: Blocked By
     url: "#blocked-by"
   - title: Freeze Windows
@@ -266,7 +268,9 @@ jobs:
     requires: [~sd@3:main]
 ```
 
-### Caveats of Using Remote Triggers and Remote Join
+### Caveats
+
+_Section covering known limitations and special considerations when using remote triggers and remote join in workflows._
 
 - In the downstream remote job (e.g.: for instance, in pipeline 2 or pipeline 4 examples above), we currently do not support `AND` syntax (e.g.: `requires: [sd@3:main]` or `requires: [sd@3:main, sd@1:main]`) for external triggers in the start nodes; you must use `OR` syntax for these nodes (e.g.: `requires: [~sd@3:main]` or `requires: [~sd@3:main, ~sd@1:main]`)
 - This feature is only guaranteed one external dependency level deep


### PR DESCRIPTION
## Context

No hyperlink right now to the section on the limitations when using remote workflow. 

## Objective

Provide a hyperlink for that section so easier to navigate when sharing the documentation. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
