### PR TITLE
feat(3106): Add job annotations to customizable field for pipeline template

### DIFF
--- a/docs/ja/user-guide/templates/pipeline-templates.md
+++ b/docs/ja/user-guide/templates/pipeline-templates.md
@@ -82,8 +82,8 @@ Example `screwdriver.yaml`:
 ```yaml
 template: nodejs/test@1.0.4
 shared:
-  environment: 
-    FOO: bar        
+  environment:
+    FOO: bar
 ```
 
 バージョンは[semver](https://semver.org/)互換です。例えば上記のテンプレートでは`nodejs/test@1`や`nodejs/test@1.0`と指定できます。
@@ -107,7 +107,7 @@ shared がパイプラインテンプレート、またはテンプレートを�
 #### Jobs
 パイプラインテンプレートを使用時に、`jobs`設定内でいくつかのカスタマイズが可能です。
 
-パイプラインテンプレートに*既に存在する*名前のユーザー定義ジョブについては、`image`、`settings`、`environment`、`requires`のフィールドのみカスタマイズが可能です。
+パイプラインテンプレートに*既に存在する*名前のユーザー定義ジョブについては、`image`、`settings`、`environment`、`annotations`、`requires`のフィールドのみカスタマイズが可能です。
 
 パイプラインテンプレート内に*存在しない*名前のユーザー定義ジョブについては、すべてのフィールドでカスタマイズが可能です。
 

--- a/docs/user-guide/templates/pipeline-templates.md
+++ b/docs/user-guide/templates/pipeline-templates.md
@@ -95,7 +95,7 @@ If no template version is specified, the most recently published will be used. T
 The most reliable way to avoid unexpected template changes is to refer to a specific version of the template. For instance, `nodejs/test@1.0.4` is an immutable reference to a particular list of steps. Using a reference such as `nodejs/test@1.0` means that a job will automatically use `nodejs/test@1.0.5` when it becomes available, but that comes with risk of an unexpected change in behavior.
 
 ### Customization
-Many fields can be customized when using Pipeline Template: shared, jobs, cache, subscribe, parameters, annotations, and stages. 
+Many fields can be customized when using Pipeline Template: shared, jobs, cache, subscribe, parameters, annotations, and stages.
 
 #### Shared
 When `shared` is set in either the Pipeline Template or user yaml, priority will be (in decreasing order): user job > user shared > pipeline template job > pipeline template shared
@@ -103,7 +103,7 @@ When `shared` is set in either the Pipeline Template or user yaml, priority will
 #### Jobs
 Some customization can be done within the `jobs` configuration when using a Pipeline Template.
 
-For user-defined jobs with names that *already exist* in the pipeline template, customization is limited to a set of certain fields: `image`, `settings`, `environment`, and `requires`.
+For user-defined jobs with names that *already exist* in the pipeline template, customization is limited to a set of certain fields: `image`, `settings`, `environment`, `annotations`, and `requires`.
 
 For user-defined jobs with names that *do not already exist* in the pipeline template, all jobs fields are allowed.
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The job level annotations fields was allowed for pipeline template.
https://github.com/screwdriver-cd/config-parser/pull/171

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add `annotations` fields to customizable fields for pipeline template.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3106

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
