### PR TITLE
fix: use openapi.json instead of default swagger.json in api docs

### DIFF
--- a/docs/ja/user-guide/api.md
+++ b/docs/ja/user-guide/api.md
@@ -39,7 +39,7 @@ ScrewdriverのAPIとデータモデルは[Swagger](http://swagger.io/)を使っ�
 
 > 現在のAPIは**Version 4**で、全てのAPIは`/v4`で始まります。
 
-APIのドキュメントは次のURLで確認できます: [api.screwdriver.cd/v4/documentation](https://api.screwdriver.cd/v4/documentation)
+APIのドキュメントは次のURLで確認できます: [api.screwdriver.cd/v4/documentation](https://api.screwdriver.cd/v4/documentation?url=/v4/openapi.json)
 
 各自のScrewdriver.cdインスタンスでは、`<API URL>/v4/documentation`にアクセスしてください。
 
@@ -163,6 +163,6 @@ APIでは、リクエストごとのペイロードサイズが最大1MBに制�
 ## 自作する
 
 Swaggerドキュメントを作成したい場合は、次のJSONを参考にしてください:
- [https://api.screwdriver.cd/v4/swagger.json](https://api.screwdriver.cd/v4/swagger.json)
+ [https://api.screwdriver.cd/v4/openapi.json](https://api.screwdriver.cd/v4/openapi.json)
 
-各自のScrewdriver.cdインスタンスでは、`/v4/swagger.json` にアクセスしてください。
+各自のScrewdriver.cdインスタンスでは、`/v4/openapi.json` にアクセスしてください。

--- a/docs/user-guide/api.md
+++ b/docs/user-guide/api.md
@@ -39,7 +39,7 @@ Screwdriver APIs and the data models around them are documented via [Swagger]. T
 
 > **Version 4** is the current API, all links should be prefixed with `/v4`.
 
-Our API documentation can be found at [api.screwdriver.cd/v4/documentation](https://api.screwdriver.cd/v4/documentation). To see yours, go to `<API URL>/v4/documentation`.
+Our API documentation can be found at [api.screwdriver.cd/v4/documentation](https://api.screwdriver.cd/v4/documentation?url=/v4/openapi.json). To see yours, go to `<API URL>/v4/documentation`.
 
 ## Using the API
 
@@ -170,7 +170,7 @@ The API enforces a maximum payload size of 1 MB per request. This limitation is 
 
 ## Make Your Own
 
-If you'd like to make your own Swagger documentation, check out our JSON for reference at [https://api.screwdriver.cd/v4/swagger.json](https://api.screwdriver.cd/v4/swagger.json). To see your Swagger.json, visit `/v4/swagger.json`.
+If you'd like to make your own Swagger documentation, check out our JSON for reference at [https://api.screwdriver.cd/v4/openapi.json](https://api.screwdriver.cd/v4/openapi.json). To see your Swagger.json, visit `/v4/openapi.json`.
 
 [JSON Web Tokens]: http://jwt.io
 [GitHub OAuth]: https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps


### PR DESCRIPTION
## Context

Opening the API Documentation link currently shows a 404 error because it can't find the `/v4/swagger.json` file.

## Objective

Update the links to refer to `/v4/openapi.json` instead of `/v4/swagger.json`

## References

https://api.screwdriver.cd/v4/documentation

https://api.screwdriver.cd/v4/documentation?url=/v4/openapi.json

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
