### PR TITLE
Add note about child repository requirements

### DIFF
--- a/docs/user-guide/configuration/externalConfig.md
+++ b/docs/user-guide/configuration/externalConfig.md
@@ -21,6 +21,8 @@ External config allows a single parent pipeline to create and manage the build c
 
 This feature allows easier management of multiple repositories with the same workflow.
 
+> Please note that a repository can only be added as a child if there are no pipelines already configured for the repository.
+
 ## Configure external config in parent pipeline
 In your parent repository's `screwdriver.yaml`, you can define child pipelines with the keyword `childPipelines`. Screwdriver will create or delete child pipelines on your behalf based on the listed `scmUrls`. Please make sure you have **admin** access in each child repository in order to manage child pipelines through this feature.
 


### PR DESCRIPTION
## Context
The documentation for configuring external configurations indicates that a child repository URL can contain a branch.  Additionally, a repository can have multiple pipelines configured as long as the pipelines are configured off of different branches.  The previous points creates confusion because it would indicate that it is possible for a repository to also be a child pipeline; however, that is not the case.

## Objective
Add an additional note specifying that a child repository can not have any pipelines configured.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
