### PR TITLE
fix: Change example repository

### DIFF
--- a/docs/ja/user-guide/configuration/externalConfig.md
+++ b/docs/ja/user-guide/configuration/externalConfig.md
@@ -32,10 +32,10 @@ Screwdriverは`scmUrls`リストに基づいて子パイプラインを作成、
 ```yaml
 childPipelines:
   scmUrls:
-    - git@github.com:minz1027/test.template.git
-    - git@github.com:minz1027/quickstart-generic.git#main
+    - git@github.com:screwdriver-cd/test.template.git
+    - git@github.com:screwdriver-cd/quickstart-generic.git#main
     # ソースディレクトリがルートでないパイプラインもURLの後に:<ソースディレクトリ>を追加することで子パイプラインにできます
-    - git@github.com:minz1027/quickstart-generic.git#main:path/to/subdir
+    - git@github.com:screwdriver-cd/quickstart-generic.git#main:path/to/subdir
     # read-only SCM。このオプションが利用可能かどうかは、クラスタ管理者に問い合わせてください。
     - https://sd.gitlab.com/screwdriver-cd/data-schema.git
 

--- a/docs/user-guide/configuration/externalConfig.md
+++ b/docs/user-guide/configuration/externalConfig.md
@@ -29,10 +29,10 @@ In your parent repository's `screwdriver.yaml`, you can define child pipelines w
 ```yaml
 childPipelines:
    scmUrls:
-      - git@github.com:minz1027/test.template.git
-      - git@github.com:minz1027/quickstart-generic.git#main
+      - git@github.com:screwdriver-cd/test.template.git
+      - git@github.com:screwdriver-cd/quickstart-generic.git#main
       # can have child pipeline with source dir not at checkout root by adding :<sourceDir> at the end of the scmUrl
-      - git@github.com:minz1027/quickstart-generic.git#main:path/to/subdir
+      - git@github.com:screwdriver-cd/quickstart-generic.git#main:path/to/subdir
       # read-only SCM. Check with your cluster admin for availability
       - https://sd.gitlab.com/screwdriver-cd/data-schema.git
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
         - bundle_install: bundle install
         - build: bundle exec jekyll build --source docs --destination _site
-        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/,/github\.com/,/kubernetes\.io/,/opensource\.org/,/twitter\.com/,/linux\.die\.net/' --http-status-ignore 429 _site
+        - proof: bundle exec htmlproofer --assume-extension --allow-hash-href --url-ignore '/bitbucket/,/gitlab/,/api\.screwdriver\.cd/,/github\.com/,/kubernetes\.io/,/opensource\.org/,/twitter\.com/,/linux\.die\.net/,/www\.npmjs\.com/' --http-status-ignore 429 _site
 
   publish:
       image: ruby:2


### PR DESCRIPTION
## Context
The example external configuration repository is unclaimed account.  Although these are just examples, it would be best to use an account that is controlled by Screwdriver.

## Objective
Changes the example repository account to `screwdriver-cd` as it is owned by the Screwdriver team.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
