### PR TITLE
fix: disable directory listing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN set -x \
 
 EXPOSE 4000
 
-CMD ["jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000"]
+CMD ["ruby", "-r", "./disable_dir_listing.rb", "/usr/local/bundle/bin/jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000"]

--- a/docs/disable_dir_listing.rb
+++ b/docs/disable_dir_listing.rb
@@ -1,0 +1,14 @@
+require "webrick"
+
+module WEBrick
+  module HTTPServlet
+    class FileHandler
+      alias original_initialize initialize
+
+      def initialize(server, local_path, options = {})
+        options = options.merge(FancyIndexing: false)
+        original_initialize(server, local_path, options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Directory listing is turned on for Webrick. But Jekyll has no option to disable that for Webrick

## Objective

Monkey patch Webrick with `FancyIndexing: false` to turn off directory listing

## References

Report from security scan

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
